### PR TITLE
feat: add migration to create kyc_verifications table with enums and …

### DIFF
--- a/supabase/migrations/20260121181100_create_kyc_verifications_table.sql
+++ b/supabase/migrations/20260121181100_create_kyc_verifications_table.sql
@@ -1,0 +1,75 @@
+-- Migration: create kyc_verifications table and supporting enums
+-- Idempotent: uses IF NOT EXISTS checks to allow safe re-runs
+
+-- Enum for KYC status
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'kyc_status') then
+    create type public.kyc_status as enum ('none', 'pending', 'verified', 'rejected');
+  end if;
+end;
+$$;
+
+-- Enum for verification level
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'verification_level') then
+    create type public.verification_level as enum ('L0', 'L1', 'L2');
+  end if;
+end;
+$$;
+
+-- Core kyc_verifications table
+create table if not exists public.kyc_verifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  provider text not null,
+  status public.kyc_status not null default 'none',
+  verification_level public.verification_level not null default 'L0',
+  verified_at timestamptz,
+  risk_flags jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Check constraint: verified_at only set when status is 'verified'
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'kyc_verifications_verified_at_status_check'
+  ) then
+    alter table public.kyc_verifications
+      add constraint kyc_verifications_verified_at_status_check 
+      check (
+        (status = 'verified' and verified_at is not null) or 
+        (status != 'verified' and verified_at is null)
+      );
+  end if;
+end;
+$$;
+
+-- Index on user_id for user KYC queries
+create index if not exists idx_kyc_verifications_user_id 
+  on public.kyc_verifications (user_id);
+
+-- Index on status for filtering by verification status
+create index if not exists idx_kyc_verifications_status 
+  on public.kyc_verifications (status);
+
+-- Composite index for common query pattern: get user's verifications by status
+create index if not exists idx_kyc_verifications_user_status 
+  on public.kyc_verifications (user_id, status);
+
+-- Comment on table for documentation
+comment on table public.kyc_verifications is 
+  'Stores KYC verification status and metadata. Privacy-first: no biometric or document data stored.';
+
+comment on column public.kyc_verifications.provider is 
+  'KYC provider name (e.g., sumsub, onfido)';
+
+comment on column public.kyc_verifications.risk_flags is 
+  'Flexible JSONB structure for risk metadata from providers';
+
+comment on column public.kyc_verifications.verified_at is 
+  'Timestamp when verification completed. Only set when status is verified.';


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3

---

## 🔖 Title
Create kyc_verifications table with status integrity constraints

---

## � Description
This PR implements the `kyc_verifications` table to store KYC verification status and metadata. It follows a privacy-first approach by only storing provider references and status flags, without any biometric or sensitive document data. 

It also includes a strict integrity constraint to ensure that the `verified_at` timestamp is only present when the status is exactly `'verified'`.

---

## 🔄 Changes Made
- [x] Created idempotent migration: `20260121181100_create_kyc_verifications_table.sql`
- [x] Defined `kyc_status` enum: `none`, `pending`, `verified`, `rejected`
- [x] Defined `verification_level` enum: `L0`, `L1`, `L2`
- [x] Implemented `kyc_verifications` table with FK to `users.id` (on delete cascade)
- [x] Added `kyc_verifications_verified_at_status_check` constraint
- [x] Added optimized indexes for `user_id`, `status`, and a composite `(user_id, status)` index

---

## 🧪 Testing Performed

### ✅ Positive Tests (Success)
- **Test A: Pending Verification**
  ```sql
  INSERT INTO public.kyc_verifications (user_id, provider, status, verification_level)
  VALUES ('6ddcdd65-f712-484a-946a-76184088b626', 'sumsub', 'pending', 'L1');
  ```
  *Result: Successfully inserted.*

- **Test B: Full Verification**
  ```sql
  INSERT INTO public.kyc_verifications (user_id, provider, status, verification_level, verified_at)
  VALUES ('6ddcdd65-f712-484a-946a-76184088b626', 'onfido', 'verified', 'L2', now());
  ```
  *Result: Successfully inserted.*
  
  
<img width="1589" height="309" alt="image" src="https://github.com/user-attachments/assets/0b05bbf3-3a0c-4f54-987b-f46281ca480a" />


### ❌ Negative Tests (Validation Errors)
- **Test C: Constraint Violation (Data Integrity)**
  ```sql
  -- MUST FAIL: violates kyc_verifications_verified_at_status_check
  INSERT INTO public.kyc_verifications (user_id, provider, status, verification_level, verified_at)
  VALUES ('6ddcdd65-f712-484a-946a-76184088b626', 'sumsub', 'verified', 'L1', NULL);
  ```
  *Result: Failed with `ERROR: 23514: violates check constraint "kyc_verifications_verified_at_status_check"`.*

- **Test D: Type and Enum Safety**
  ```sql
  -- MUST FAIL: invalid input value for enum kyc_status or invalid UUID
  INSERT INTO public.kyc_verifications (user_id, provider, status)
  VALUES ('6ddcdd65-f712-484a-946a-76184088b626', 'sumsub', 'invalid_status');
  ```
  *Result: Failed to run sql query: ERROR: 22P02: invalid input value for enum kyc_status: "invalid_status"`.*

---

## 🗒️ Additional Notes
- Privacy-first design: no images or facial data stored.
- `risk_flags` JSONB column included for flexible provider-specific risk metadata.
- Migration has been successfully pushed to the remote Supabase instance.
