### PR TITLE
feat(auth): add sessions table for wallet-based authentication

### DIFF
--- a/supabase/migrations/20260122000338_create_sessions_table.sql
+++ b/supabase/migrations/20260122000338_create_sessions_table.sql
@@ -1,0 +1,25 @@
+-- Migration: create sessions table
+-- Description: Stores active user sessions for JWT refresh token validation and device tracking
+
+create table if not exists public.sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  refresh_token text not null,
+  device_info text,
+  ip_address text,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+
+  -- Constraints
+  constraint sessions_refresh_token_key unique (refresh_token),
+  constraint sessions_expires_at_check check (expires_at > created_at)
+);
+
+-- Indexes
+create index if not exists idx_sessions_user_id on public.sessions (user_id);
+create index if not exists idx_sessions_expires_at on public.sessions (expires_at);
+
+-- Comments
+comment on table public.sessions is 'Active user sessions for refresh token validation.';
+comment on column public.sessions.refresh_token is 'Opaque JWT refresh token string.';
+comment on column public.sessions.device_info is 'User agent or device identifier.';


### PR DESCRIPTION
## 🔗 Related Issue
Closes #2 

---

## 🔖 Title
Add sessions table for wallet-based authentication

---

## 📝 Description
Introduced a new `sessions` table to manage active user sessions, secure refresh tokens, and track device information for wallet-based authentication.

---

## 🔄 Changes Made
<!-- List the main changes in this PR -->
- Created migration [20260122000338_create_sessions_table.sql]
- Defined `sessions` schema:
  - `id`: UUID (PK)
  - `user_id`: UUID (FK to `users.id`, recursing cascade delete)
  - `refresh_token`: Unique JWT refresh token
  - `device_info`: Device/browser metadata
  - `expires_at`: Token expiration timestamp
- Added constraints:
  - Unique constraint on `refresh_token`.
  - Check constraint ensuring `expires_at > created_at`.
- Added performance indexes on `user_id` and `expires_at`.

---

## 🗒️ Additional Notes
- Ran `supabase db reset` to apply the new migration.
- Verified the table exists in the public schema with the correct constraints.
- (enable rls policies migration raised an error due to referenced tables being absent. Update in future implementations)