### PR TITLE
feat: create reputation_cache table with enum and indexes for reputation #5

### DIFF
--- a/supabase/migrations/20260122235230_create_reputation_cache_table.sql
+++ b/supabase/migrations/20260122235230_create_reputation_cache_table.sql
@@ -1,0 +1,41 @@
+-- Migration: create reputation_cache table and supporting enum/indexes
+-- Idempotent: uses IF NOT EXISTS checks to allow safe re-runs
+
+-- Enum for reputation tier
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'reputation_tier') then
+    create type public.reputation_tier as enum ('bronze', 'silver', 'gold');
+  end if;
+end;
+$$;
+
+-- Core reputation cache table
+create table if not exists public.reputation_cache (
+  user_id uuid primary key references public.users(id) on delete cascade,
+  wallet_address text not null,
+  score integer not null,
+  tier public.reputation_tier,
+  last_synced_at timestamp default now()
+);
+
+-- Score range constraint
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'reputation_cache_score_range_check'
+  ) then
+    alter table public.reputation_cache
+      add constraint reputation_cache_score_range_check
+      check (score >= 0 and score <= 1000);
+  end if;
+end;
+$$;
+
+-- Indexes for common queries
+create index if not exists idx_reputation_cache_wallet_address
+  on public.reputation_cache (wallet_address);
+create index if not exists idx_reputation_cache_last_synced_at
+  on public.reputation_cache (last_synced_at);


### PR DESCRIPTION
Closes #5
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/34888439-78fc-48c4-992b-d8c366e8f534" />

This pull request introduces a new database migration to support user reputation caching. The migration is idempotent and ensures safe re-runs by checking for existing types, tables, and constraints before creation. The main changes establish a new table, supporting enum, constraints, and indexes to optimize reputation-related queries.

**Database schema changes:**

* Added a new enum type `reputation_tier` with values `'bronze'`, `'silver'`, and `'gold'` for categorizing user reputation levels.
* Created a new table `reputation_cache` to store user reputation data, including fields for `user_id`, `wallet_address`, `score`, `tier`, and `last_synced_at`. The table references the `users` table and uses `user_id` as the primary key.
* Added a check constraint `reputation_cache_score_range_check` to enforce that the `score` is between 0 and 1000.
* Created indexes on `wallet_address` and `last_synced_at` columns in the `reputation_cache` table to improve query performance.
@Josue19-08 