### PR TITLE
fix(migrations): correct 5 database schema issues found during audit

### DIFF
--- a/supabase/migrations/20260213001000_create_user_preferences_table.sql
+++ b/supabase/migrations/20260213001000_create_user_preferences_table.sql
@@ -1,0 +1,58 @@
+-- Migration: create user_preferences table
+-- Description: Stores user notification and UI preferences.
+--              This table was referenced in RLS policies but was missing a creation migration.
+-- Idempotent: uses IF NOT EXISTS checks to allow safe re-runs
+
+-- Core user_preferences table
+create table if not exists public.user_preferences (
+  user_id uuid primary key references public.users(id) on delete cascade,
+  notifications_enabled boolean not null default true,
+  language text not null default 'en',
+  theme text not null default 'system',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- Validate theme values
+  constraint user_preferences_theme_check
+    check (theme in ('light', 'dark', 'system')),
+
+  -- Validate language (ISO 639-1 two-letter codes)
+  constraint user_preferences_language_check
+    check (language ~ '^[a-z]{2}$')
+);
+
+-- Trigger function to maintain updated_at
+create or replace function public.set_user_preferences_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- Attach trigger
+do $$
+begin
+  if not exists (
+    select 1 from pg_trigger
+    where tgname = 'trg_user_preferences_updated_at'
+  ) then
+    create trigger trg_user_preferences_updated_at
+    before update on public.user_preferences
+    for each row
+    execute function public.set_user_preferences_updated_at();
+  end if;
+end;
+$$;
+
+-- Comments
+comment on table public.user_preferences is
+  'User-level preferences for notifications and UI. One row per user, auto-created on first access.';
+comment on column public.user_preferences.notifications_enabled is
+  'Whether the user wants to receive in-app notifications.';
+comment on column public.user_preferences.language is
+  'Preferred UI language as an ISO 639-1 code (e.g. en, es).';
+comment on column public.user_preferences.theme is
+  'Preferred UI theme: light, dark, or system (follows device setting).';

--- a/supabase/migrations/20260213002000_fix_reputation_cache_score_constraint.sql
+++ b/supabase/migrations/20260213002000_fix_reputation_cache_score_constraint.sql
@@ -1,0 +1,38 @@
+-- Migration: fix reputation_cache score constraint
+-- Description: The original constraint allowed scores up to 1000, but the
+--              Reputation Soroban contract stores scores as u32 in the 0–100 range.
+--              This migration drops the incorrect constraint and adds the correct one.
+-- Idempotent: uses IF NOT EXISTS / IF EXISTS checks to allow safe re-runs
+
+-- Drop the incorrect constraint if it exists
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conname = 'reputation_cache_score_range_check'
+  ) then
+    alter table public.reputation_cache
+      drop constraint reputation_cache_score_range_check;
+  end if;
+end;
+$$;
+
+-- Add the correct constraint (0–100, matching the on-chain contract range)
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'reputation_cache_score_range_check'
+  ) then
+    alter table public.reputation_cache
+      add constraint reputation_cache_score_range_check
+      check (score >= 0 and score <= 100);
+  end if;
+end;
+$$;
+
+-- Comments
+comment on column public.reputation_cache.score is
+  'On-chain reputation score in the 0–100 range, as defined by the Reputation Soroban contract.';
+comment on column public.reputation_cache.tier is
+  'Derived credit tier: bronze (0–59), silver (60–89), gold (90–100).';

--- a/supabase/migrations/20260213003000_fix_sessions_refresh_token_hashing.sql
+++ b/supabase/migrations/20260213003000_fix_sessions_refresh_token_hashing.sql
@@ -1,0 +1,89 @@
+-- Migration: fix sessions table — store refresh token hash instead of plaintext
+-- Description: Storing the raw refresh token is a security risk: a database leak
+--              exposes all active sessions. This migration renames the column to
+--              refresh_token_hash to make the intent explicit and adds a
+--              token_family column for refresh token rotation detection.
+-- Idempotent: uses IF EXISTS / column existence checks to allow safe re-runs
+-- Security: aligns with SECURITY.md — "Hash refresh tokens before storage"
+
+-- 1. Rename refresh_token → refresh_token_hash to signal hashed storage
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'sessions'
+      and column_name  = 'refresh_token'
+  ) then
+    alter table public.sessions
+      rename column refresh_token to refresh_token_hash;
+  end if;
+end;
+$$;
+
+-- 2. Drop old unique constraint on the original column name (if still present)
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conname = 'sessions_refresh_token_key'
+  ) then
+    alter table public.sessions
+      drop constraint sessions_refresh_token_key;
+  end if;
+end;
+$$;
+
+-- 3. Re-add unique constraint under the new column name
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'sessions_refresh_token_hash_key'
+  ) then
+    alter table public.sessions
+      add constraint sessions_refresh_token_hash_key
+      unique (refresh_token_hash);
+  end if;
+end;
+$$;
+
+-- 4. Add token_family column for refresh token rotation (detect reuse attacks)
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'sessions'
+      and column_name  = 'token_family'
+  ) then
+    alter table public.sessions
+      add column token_family uuid not null default gen_random_uuid();
+  end if;
+end;
+$$;
+
+-- 5. Add revoked_at column for explicit session invalidation
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'sessions'
+      and column_name  = 'revoked_at'
+  ) then
+    alter table public.sessions
+      add column revoked_at timestamptz;
+  end if;
+end;
+$$;
+
+-- Comments
+comment on column public.sessions.refresh_token_hash is
+  'SHA-256 hex hash of the refresh token. The raw token is never stored. '
+  'On verify: hash the incoming token and compare.';
+comment on column public.sessions.token_family is
+  'Groups tokens from the same original session. If a revoked token from this '
+  'family is used, the entire family is invalidated (rotation attack detection).';
+comment on column public.sessions.revoked_at is
+  'Timestamp when this session was explicitly revoked. NULL means active.';

--- a/supabase/migrations/20260213004000_fix_rls_policies.sql
+++ b/supabase/migrations/20260213004000_fix_rls_policies.sql
@@ -1,0 +1,178 @@
+-- Migration: fix RLS policies
+-- Description: Two issues found in the original enable_rls_policies migration:
+--
+--   1. users table policy used `auth.uid() = id`, but Supabase Auth UIDs do not
+--      match the internal users.id (generated independently with gen_random_uuid()).
+--      The correct join is through wallet_address, which is stored in the JWT
+--      claims under the custom claim `wallet`. This migration drops the broken
+--      policies and replaces them with wallet-based ones.
+--
+--   2. user_preferences RLS policies referenced a table that did not exist yet
+--      (20260213001000 creates it). Those policies are recreated here safely.
+--
+-- Idempotent: drops and re-creates each policy by name.
+
+BEGIN;
+
+-- =============================================================================
+-- USERS TABLE — replace id-based policy with wallet-based policy
+-- The API signs JWTs with { wallet } as the subject. We expose it via a
+-- Postgres function so RLS can read it without a round-trip.
+-- =============================================================================
+
+-- Helper: expose the wallet claim from the current JWT
+create or replace function public.current_wallet()
+returns text
+language sql
+stable
+as $$
+  select nullif(
+    current_setting('request.jwt.claims', true)::jsonb ->> 'wallet',
+    ''
+  );
+$$;
+
+comment on function public.current_wallet() is
+  'Returns the Stellar wallet address embedded in the current JWT, '
+  'or NULL when there is no authenticated session.';
+
+-- Drop the broken policies (if they still exist)
+drop policy if exists "users_select_own" on public.users;
+drop policy if exists "users_update_own" on public.users;
+
+-- Correct policies: match on wallet_address, not id
+create policy "users_select_own" on public.users
+  for select
+  using (wallet_address = public.current_wallet());
+
+create policy "users_update_own" on public.users
+  for update
+  using  (wallet_address = public.current_wallet())
+  with check (wallet_address = public.current_wallet());
+
+-- =============================================================================
+-- USER_PREFERENCES TABLE — enable RLS and create policies
+-- (The table is created in migration 20260213001000)
+-- =============================================================================
+
+alter table public.user_preferences enable row level security;
+
+drop policy if exists "user_preferences_select_own" on public.user_preferences;
+drop policy if exists "user_preferences_update_own" on public.user_preferences;
+drop policy if exists "user_preferences_insert_own" on public.user_preferences;
+
+-- Preferences are owned by the user; look up their id via wallet_address
+create policy "user_preferences_select_own" on public.user_preferences
+  for select
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+create policy "user_preferences_update_own" on public.user_preferences
+  for update
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  )
+  with check (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+create policy "user_preferences_insert_own" on public.user_preferences
+  for insert
+  with check (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+-- =============================================================================
+-- SESSIONS TABLE — align policy with wallet-based auth
+-- =============================================================================
+
+drop policy if exists "sessions_select_own" on public.sessions;
+
+create policy "sessions_select_own" on public.sessions
+  for select
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+-- =============================================================================
+-- NOTIFICATIONS TABLE — align policy with wallet-based auth
+-- =============================================================================
+
+drop policy if exists "notifications_select_own" on public.notifications;
+drop policy if exists "notifications_update_own" on public.notifications;
+
+create policy "notifications_select_own" on public.notifications
+  for select
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+create policy "notifications_update_own" on public.notifications
+  for update
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  )
+  with check (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+-- =============================================================================
+-- KYC_VERIFICATIONS TABLE — align policy with wallet-based auth
+-- =============================================================================
+
+drop policy if exists "kyc_verifications_select_own" on public.kyc_verifications;
+
+create policy "kyc_verifications_select_own" on public.kyc_verifications
+  for select
+  using (
+    user_id = (
+      select id from public.users
+      where wallet_address = public.current_wallet()
+      limit 1
+    )
+  );
+
+-- =============================================================================
+-- NOTES:
+-- - Service role (SUPABASE_SERVICE_ROLE_KEY) bypasses RLS automatically.
+--   Use it for indexer jobs that write to loan_index, payment_index,
+--   investments_index, and reputation_cache.
+-- - current_wallet() reads from the JWT set by the NestJS API.
+--   The JWT must include a top-level "wallet" claim.
+-- - Index tables remain read-only for authenticated users (unchanged).
+-- =============================================================================
+
+COMMIT;

--- a/supabase/migrations/20260213005000_fix_payment_index_timestamps.sql
+++ b/supabase/migrations/20260213005000_fix_payment_index_timestamps.sql
@@ -1,0 +1,68 @@
+-- Migration: fix payment_index timestamp columns — add timezone awareness
+-- Description: payment_index used plain `timestamp` (no timezone) while every
+--              other table in the schema uses `timestamptz`. This inconsistency
+--              can produce silent time-offset bugs for users in non-UTC timezones.
+--              This migration converts both columns to timestamptz.
+-- Idempotent: checks column type before altering
+
+-- Convert paid_at to timestamptz
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'payment_index'
+      and column_name  = 'paid_at'
+      and data_type    = 'timestamp without time zone'
+  ) then
+    alter table public.payment_index
+      alter column paid_at type timestamptz
+      using paid_at at time zone 'UTC';
+  end if;
+end;
+$$;
+
+-- Convert created_at to timestamptz and add NOT NULL + default
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'payment_index'
+      and column_name  = 'created_at'
+      and data_type    = 'timestamp without time zone'
+  ) then
+    alter table public.payment_index
+      alter column created_at type timestamptz
+      using created_at at time zone 'UTC';
+
+    alter table public.payment_index
+      alter column created_at set not null;
+
+    alter table public.payment_index
+      alter column created_at set default now();
+  end if;
+end;
+$$;
+
+-- Add missing tx_hash unique constraint to prevent duplicate indexing
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'payment_index_tx_hash_key'
+  ) then
+    alter table public.payment_index
+      add constraint payment_index_tx_hash_key unique (tx_hash);
+  end if;
+end;
+$$;
+
+-- Comments
+comment on table public.payment_index is
+  'Off-chain index of on-chain loan repayment transactions. '
+  'Written only by the chain indexer job using the service role.';
+comment on column public.payment_index.paid_at is
+  'UTC timestamp of the Stellar transaction that recorded this payment.';
+comment on column public.payment_index.tx_hash is
+  'Stellar transaction hash. Unique — prevents duplicate indexing.';


### PR DESCRIPTION
## 🔗 Related Issue
Identified during database schema audit prior to API development.

---

## 🔖 Title
Fix database schema issues found during migration audit

---

## 📝 Description
A deep audit of all existing Supabase migrations revealed 6 issues ranging from a missing foundational table to a critical security vulnerability and broken RLS policies that would have blocked the entire authentication system. All fixes are delivered as new idempotent migrations — no existing migration files were modified.

---

## 🔄 Changes Made

### 0. `20260120000000` — Add missing `users` table 🔴 Critical (BLOCKER)
- [ ] `users` is the root table referenced by **every other table** via FK
- [ ] No creation migration existed — the entire migration chain fails on first run
- [ ] Timestamp set to `20260120000000` to guarantee it runs before all others

### 1. `20260213001000` — Create missing `user_preferences` table 🔴 Critical
- [ ] `enable_rls_policies.sql` referenced `user_preferences` but no creation migration existed
- [ ] Added `notifications_enabled`, `language`, `theme` columns with check constraints
- [ ] Includes `updated_at` auto-update trigger consistent with `users` table pattern

### 2. `20260213002000` — Fix `reputation_cache.score` constraint 🔴 Critical
- [ ] Constraint allowed scores up to **1000** — the on-chain contract defines scores as `u32` in the **0–100** range
- [ ] Drops the wrong constraint and replaces it with `check (score >= 0 and score <= 100)`

### 3. `20260213003000` — Fix `sessions.refresh_token` security 🔴 Security
- [ ] `refresh_token` was stored in **plaintext** — a database leak exposes all active sessions
- [ ] Renamed column to `refresh_token_hash` to make intent explicit
- [ ] Added `token_family` for rotation attack detection
- [ ] Added `revoked_at` for explicit session invalidation
- [ ] Aligns with [`SECURITY.md`](../SECURITY.md): _"Hash refresh tokens before storage"_

### 4. `20260213004000` — Fix RLS policies to use wallet-based auth 🔴 Critical
- [ ] All user-scoped policies used `auth.uid() = id` — comparison **never evaluates to true**
- [ ] Added `current_wallet()` helper to read the `wallet` claim from JWT
- [ ] Fixed policies across: `users`, `sessions`, `notifications`, `kyc_verifications`, `user_preferences`

### 5. `20260213005000` — Fix `payment_index` timestamp timezone 🟡 Inconsistency
- [ ] `paid_at` and `created_at` used `timestamp` (no tz) vs `timestamptz` everywhere else
- [ ] Converted both columns; added `UNIQUE` on `tx_hash` to prevent duplicate indexing

---

## 📸 Screenshots (if applicable)
N/A — database migrations only.

---

## 🗒️ Additional Notes

**All migrations are idempotent** — `IF EXISTS` / `IF NOT EXISTS` checks allow safe re-runs.

**No existing migration files were modified.** All fixes are additive.

**Correct execution order:**
```
20260120000000 → users table               ← NEW (must be first)
20260121163700 → enable_rls_policies       ← existing
20260121181100 → kyc_verifications         ← existing
20260122000338 → sessions                  ← existing
20260122104500 → investments_index         ← existing
20260122215751 → loan_index               ← existing
20260122233919 → payment_index            ← existing
20260122235230 → reputation_cache          ← existing
20260125192000 → notifications             ← existing
20260213001000 → user_preferences          ← NEW
20260213002000 → fix reputation score      ← NEW
20260213003000 → fix sessions security     ← NEW
20260213004000 → fix RLS policies          ← NEW
20260213005000 → fix payment timestamps    ← NEW
```

**What the API team must update after merge:**
- `AuthService`: hash tokens with SHA-256 before saving; compare hashes on verify
- `AuthService`: include `wallet` as a top-level JWT claim so `current_wallet()` works
- `ReputationService`: validate scores are in 0–100 range before inserting to cache