### PR TITLE
Feat transaction status query endpoint

### DIFF
--- a/src/modules/transactions/dto/transaction-status-response.dto.ts
+++ b/src/modules/transactions/dto/transaction-status-response.dto.ts
@@ -1,0 +1,123 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TransactionResultDetailsDto {
+  @ApiProperty({
+    description: 'Ledger sequence where the transaction was confirmed',
+    example: 123456,
+  })
+  ledger: number;
+
+  @ApiProperty({
+    description: 'Number of operations included in the transaction',
+    example: 2,
+  })
+  operationCount: number;
+
+  @ApiProperty({
+    description: 'Source Stellar account that submitted the transaction',
+    example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+  })
+  sourceAccount: string;
+
+  @ApiProperty({
+    description: 'Fee charged by the network, in stroops',
+    example: '100',
+  })
+  feeCharged: string;
+
+  @ApiProperty({
+    description: 'Memo type reported by Horizon',
+    example: 'text',
+  })
+  memoType: string;
+
+  @ApiPropertyOptional({
+    description: 'Memo value when present',
+    example: 'Loan repayment',
+    nullable: true,
+  })
+  memo?: string | null;
+
+  @ApiProperty({
+    description: 'Timestamp reported by Horizon for transaction creation/confirmation',
+    example: '2026-03-23T05:15:30Z',
+  })
+  createdAt: string;
+}
+
+export class TransactionErrorDetailsDto {
+  @ApiProperty({
+    description: 'Normalized Stellar transaction error code',
+    example: 'tx_insufficient_balance',
+  })
+  code: string;
+
+  @ApiProperty({
+    description: 'Human-readable description of the failure',
+    example: 'Insufficient balance to cover this transaction.',
+  })
+  message: string;
+
+  @ApiPropertyOptional({
+    description: 'Operation-level result codes when Horizon exposes them',
+    example: ['op_underfunded'],
+    type: [String],
+  })
+  operationCodes?: string[];
+}
+
+export class TransactionStatusResponseDto {
+  @ApiProperty({
+    description: 'Stellar transaction hash',
+    example: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  })
+  hash: string;
+
+  @ApiProperty({
+    description: 'Normalized transaction status',
+    enum: ['pending', 'success', 'failed'],
+    example: 'success',
+  })
+  status: 'pending' | 'success' | 'failed';
+
+  @ApiPropertyOptional({
+    description: 'Application transaction type stored in the database when available',
+    example: 'loan_repay',
+    nullable: true,
+  })
+  type?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Parsed details for successful transactions',
+    type: TransactionResultDetailsDto,
+    nullable: true,
+  })
+  result?: TransactionResultDetailsDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Failure details for rejected or unsuccessful transactions',
+    type: TransactionErrorDetailsDto,
+    nullable: true,
+  })
+  error?: TransactionErrorDetailsDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Timestamp when the API first recorded the transaction locally',
+    example: '2026-03-23T05:15:00.000Z',
+    nullable: true,
+  })
+  submittedAt?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Timestamp when the transaction was confirmed on Stellar',
+    example: '2026-03-23T05:15:30Z',
+    nullable: true,
+  })
+  confirmedAt?: string | null;
+
+  @ApiProperty({
+    description: 'Timestamp of the latest status check performed by this API',
+    example: '2026-03-23T05:16:00.000Z',
+  })
+  lastCheckedAt: string;
+}

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -1,10 +1,13 @@
 import {
   Controller,
   Post,
+  Get,
   Body,
+  Param,
   HttpCode,
   HttpStatus,
   UseGuards,
+  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -15,12 +18,15 @@ import {
 import { TransactionsService } from './transactions.service';
 import { SubmitTransactionRequestDto } from './dto/submit-transaction-request.dto';
 import { SubmitTransactionResponseDto } from './dto/submit-transaction-response.dto';
+import { TransactionStatusResponseDto } from './dto/transaction-status-response.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
 @ApiTags('transactions')
 @Controller('transactions')
 export class TransactionsController {
+  private static readonly TRANSACTION_HASH_REGEX = /^[a-f0-9]{64}$/i;
+
   constructor(private readonly transactionsService: TransactionsService) {}
 
   @Post('submit')
@@ -49,6 +55,40 @@ export class TransactionsController {
       success: true,
       data,
       message: 'Transaction submitted successfully',
+    };
+  }
+
+  @Get(':hash')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get Stellar transaction status by hash',
+    description:
+      'Looks up a Stellar transaction in Horizon, normalizes its status to pending/success/failed, and returns cached finalized results when available. This endpoint is public and does not require authentication.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Transaction status retrieved successfully',
+    type: TransactionStatusResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid transaction hash format' })
+  @ApiResponse({ status: 404, description: 'Transaction hash not found' })
+  @ApiResponse({ status: 503, description: 'Horizon API temporarily unavailable' })
+  async getTransactionStatus(
+    @Param('hash') hash: string,
+  ): Promise<{ success: boolean; data: TransactionStatusResponseDto; message: string }> {
+    if (!TransactionsController.TRANSACTION_HASH_REGEX.test(hash)) {
+      throw new BadRequestException({
+        code: 'TRANSACTION_INVALID_HASH',
+        message: 'Transaction hash must be a 64-character hexadecimal string.',
+      });
+    }
+
+    const data = await this.transactionsService.getTransactionStatus(hash);
+
+    return {
+      success: true,
+      data,
+      message: 'Transaction status retrieved successfully',
     };
   }
 }

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -1,12 +1,22 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { CacheModule } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TransactionsController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
 import { AuthModule } from '../auth/auth.module';
 import { SupabaseService } from '../../database/supabase.client';
+import { getRedisConfig } from '../../config/redis.config';
 
 @Module({
-  imports: [ConfigModule, AuthModule],
+  imports: [
+    ConfigModule,
+    AuthModule,
+    CacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: getRedisConfig,
+    }),
+  ],
   controllers: [TransactionsController],
   providers: [TransactionsService, SupabaseService],
   exports: [TransactionsService],

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -1,19 +1,29 @@
 import {
   Injectable,
+  Inject,
   BadRequestException,
   InternalServerErrorException,
+  NotFoundException,
   ServiceUnavailableException,
   Logger,
 } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
+import { Cache } from 'cache-manager';
 import * as StellarSdk from 'stellar-sdk';
 import { SupabaseService } from '../../database/supabase.client';
 import { SubmitTransactionRequestDto, TransactionType } from './dto/submit-transaction-request.dto';
 import { SubmitTransactionResponseDto } from './dto/submit-transaction-response.dto';
+import {
+  TransactionErrorDetailsDto,
+  TransactionResultDetailsDto,
+  TransactionStatusResponseDto,
+} from './dto/transaction-status-response.dto';
 
 const HORIZON_ERROR_MAP: Record<string, string> = {
   op_bad_auth: 'Invalid transaction signature. Please re-sign and try again.',
   op_no_source_account: 'Source account not found on the Stellar network.',
+  op_underfunded: 'Insufficient balance to complete one or more operations in this transaction.',
   tx_bad_seq: 'Transaction sequence number is outdated. Please rebuild the transaction.',
   tx_insufficient_balance: 'Insufficient balance to cover this transaction.',
   tx_bad_auth: 'Invalid transaction signature. Please re-sign and try again.',
@@ -24,6 +34,33 @@ const HORIZON_ERROR_MAP: Record<string, string> = {
   tx_no_account: 'Source account does not exist on the Stellar network.',
 };
 
+type TransactionLookupColumn = 'hash' | 'transaction_hash';
+type TransactionStatus = 'pending' | 'success' | 'failed';
+type HorizonTransactionRecord = {
+  hash: string;
+  successful: boolean;
+  ledger_attr: number;
+  operation_count: number;
+  source_account: string;
+  fee_charged: number | string;
+  memo_type: string;
+  memo?: string;
+  created_at: string;
+  result_xdr: string;
+};
+
+type TransactionRecord = {
+  lookupColumn: TransactionLookupColumn;
+  hash: string;
+  type: string | null;
+  status: TransactionStatus | null;
+  submittedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string | null;
+};
+
+const FINALIZED_TRANSACTION_CACHE_TTL = 0;
+
 @Injectable()
 export class TransactionsService {
   private readonly logger = new Logger(TransactionsService.name);
@@ -31,6 +68,7 @@ export class TransactionsService {
   private readonly networkPassphrase: string;
 
   constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly configService: ConfigService,
     private readonly supabaseService: SupabaseService,
   ) {
@@ -71,6 +109,46 @@ export class TransactionsService {
     );
 
     return { transactionHash, status: 'pending' };
+  }
+
+  async getTransactionStatus(hash: string): Promise<TransactionStatusResponseDto> {
+    const normalizedHash = hash.toLowerCase();
+    const cacheKey = `transactions:status:${normalizedHash}`;
+
+    const cached = await this.cacheManager.get<TransactionStatusResponseDto>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const transactionRecord = await this.findTransactionRecord(normalizedHash);
+
+    try {
+      const horizonTransaction = await this.horizonServer
+        .transactions()
+        .includeFailed(true)
+        .transaction(normalizedHash)
+        .call();
+
+      const response = this.buildFinalizedTransactionResponse(horizonTransaction, transactionRecord);
+
+      await this.cacheManager.set(cacheKey, response, FINALIZED_TRANSACTION_CACHE_TTL);
+      await this.persistFinalizedTransaction(transactionRecord, response);
+
+      return response;
+    } catch (error) {
+      if (this.isHorizonNotFoundError(error)) {
+        if (transactionRecord) {
+          return this.buildPendingTransactionResponse(normalizedHash, transactionRecord);
+        }
+
+        throw new NotFoundException({
+          code: 'TRANSACTION_NOT_FOUND',
+          message: 'Transaction hash was not found in Horizon or local records.',
+        });
+      }
+
+      this.handleHorizonLookupError(error, normalizedHash);
+    }
   }
 
   private parseXdr(xdr: string): StellarSdk.Transaction | StellarSdk.FeeBumpTransaction {
@@ -133,16 +211,240 @@ export class TransactionsService {
     type: TransactionType,
   ): Promise<void> {
     const client = this.supabaseService.getServiceRoleClient();
-    const { error } = await client.from('transactions').insert({
-      user_wallet: wallet,
-      transaction_hash: hash,
-      type,
-      status: 'pending',
-      submitted_at: new Date().toISOString(),
-    });
+    const submittedAt = new Date().toISOString();
 
-    if (error) {
-      throw new Error(error.message ?? 'Supabase insert failed');
+    const payloads = [
+      {
+        hash,
+        user_wallet: wallet,
+        type,
+        status: 'pending',
+        submitted_at: submittedAt,
+      },
+      {
+        transaction_hash: hash,
+        user_wallet: wallet,
+        type,
+        status: 'pending',
+        submitted_at: submittedAt,
+      },
+    ];
+
+    let lastError: { message?: string } | null = null;
+
+    for (const payload of payloads) {
+      const { error } = await client.from('transactions').insert(payload);
+      if (!error) {
+        return;
+      }
+
+      lastError = error;
+      if (!this.isUnknownColumnError(error)) {
+        break;
+      }
     }
+
+    if (lastError) {
+      throw new Error(lastError.message ?? 'Supabase insert failed');
+    }
+  }
+
+  private async findTransactionRecord(hash: string): Promise<TransactionRecord | null> {
+    const client = this.supabaseService.getServiceRoleClient();
+
+    for (const column of ['hash', 'transaction_hash'] as TransactionLookupColumn[]) {
+      const selectColumns = [
+        column,
+        'type',
+        'status',
+        'submitted_at',
+        'completed_at',
+        'updated_at',
+      ].join(', ');
+      const { data, error } = await client
+        .from('transactions')
+        .select(selectColumns)
+        .eq(column, hash)
+        .maybeSingle();
+
+      if (error) {
+        if (this.isUnknownColumnError(error)) {
+          continue;
+        }
+
+        throw new InternalServerErrorException({
+          code: 'TRANSACTION_LOOKUP_DB_FAILED',
+          message: 'Failed to read transaction metadata from the database.',
+        });
+      }
+
+      if (!data) {
+        continue;
+      }
+
+      const row = data as unknown as Record<string, unknown>;
+      return {
+        lookupColumn: column,
+        hash: String(row[column] ?? hash).toLowerCase(),
+        type: row.type ? String(row.type) : null,
+        status: row.status ? (String(row.status) as TransactionStatus) : null,
+        submittedAt: row.submitted_at ? String(row.submitted_at) : null,
+        completedAt: row.completed_at ? String(row.completed_at) : null,
+        updatedAt: row.updated_at ? String(row.updated_at) : null,
+      };
+    }
+
+    return null;
+  }
+
+  private buildPendingTransactionResponse(
+    hash: string,
+    transactionRecord: TransactionRecord,
+  ): TransactionStatusResponseDto {
+    return {
+      hash,
+      status: 'pending',
+      type: transactionRecord.type,
+      result: null,
+      error: null,
+      submittedAt: transactionRecord.submittedAt,
+      confirmedAt: null,
+      lastCheckedAt: new Date().toISOString(),
+    };
+  }
+
+  private buildFinalizedTransactionResponse(
+    transaction: HorizonTransactionRecord,
+    transactionRecord: TransactionRecord | null,
+  ): TransactionStatusResponseDto {
+    const status: TransactionStatus = transaction.successful ? 'success' : 'failed';
+    const error = transaction.successful ? null : this.extractFailureDetails(transaction.result_xdr);
+
+    return {
+      hash: transaction.hash.toLowerCase(),
+      status,
+      type: transactionRecord?.type ?? null,
+      result: transaction.successful ? this.extractSuccessDetails(transaction) : null,
+      error,
+      submittedAt: transactionRecord?.submittedAt ?? null,
+      confirmedAt: transaction.created_at,
+      lastCheckedAt: new Date().toISOString(),
+    };
+  }
+
+  private extractSuccessDetails(
+    transaction: HorizonTransactionRecord,
+  ): TransactionResultDetailsDto {
+    return {
+      ledger: transaction.ledger_attr,
+      operationCount: transaction.operation_count,
+      sourceAccount: transaction.source_account,
+      feeCharged: String(transaction.fee_charged),
+      memoType: transaction.memo_type,
+      memo: transaction.memo ?? null,
+      createdAt: transaction.created_at,
+    };
+  }
+
+  private extractFailureDetails(resultXdr: string): TransactionErrorDetailsDto {
+    try {
+      const parsed = StellarSdk.xdr.TransactionResult.fromXDR(resultXdr, 'base64');
+      const txCode = this.toSnakeCase(parsed.result().switch().name);
+      const operationResults = parsed.result().value();
+      const operationCodes = Array.isArray(operationResults)
+        ? operationResults.map((operationResult) => this.toSnakeCase(operationResult.switch().name))
+        : [];
+      const primaryCode = operationCodes[0] ?? txCode;
+
+      return {
+        code: txCode,
+        message: HORIZON_ERROR_MAP[primaryCode] ?? HORIZON_ERROR_MAP[txCode] ?? this.humanizeCode(primaryCode),
+        operationCodes: operationCodes.length > 0 ? operationCodes : undefined,
+      };
+    } catch (error) {
+      this.logger.warn(`Failed to parse transaction result XDR: ${(error as Error).message}`);
+      return {
+        code: 'tx_failed',
+        message: HORIZON_ERROR_MAP.tx_failed,
+      };
+    }
+  }
+
+  private async persistFinalizedTransaction(
+    transactionRecord: TransactionRecord | null,
+    response: TransactionStatusResponseDto,
+  ): Promise<void> {
+    if (!transactionRecord) {
+      return;
+    }
+
+    const client = this.supabaseService.getServiceRoleClient();
+    const payload = {
+      status: response.status,
+      result: response.result,
+      error: response.error?.message ?? null,
+      completed_at: response.confirmedAt,
+    };
+
+    const { error } = await client
+      .from('transactions')
+      .update(payload)
+      .eq(transactionRecord.lookupColumn, transactionRecord.hash);
+
+    if (error && !this.isUnknownColumnError(error)) {
+      this.logger.warn(
+        `Failed to persist finalized transaction ${transactionRecord.hash}: ${error.message}`,
+      );
+    }
+  }
+
+  private handleHorizonLookupError(error: unknown, hash: string): never {
+    const err = error as {
+      response?: { status?: number };
+      message?: string;
+    };
+
+    const message = err?.message?.toLowerCase() ?? '';
+    if (
+      err?.response?.status === 502 ||
+      err?.response?.status === 503 ||
+      err?.response?.status === 504 ||
+      message.includes('timeout') ||
+      message.includes('network') ||
+      message.includes('socket')
+    ) {
+      throw new ServiceUnavailableException({
+        code: 'HORIZON_UNAVAILABLE',
+        message: `Unable to query Horizon for transaction ${hash}. Please try again later.`,
+      });
+    }
+
+    this.logger.error(`Unexpected Horizon lookup error for ${hash}: ${err?.message ?? error}`);
+    throw new InternalServerErrorException({
+      code: 'TRANSACTION_STATUS_LOOKUP_FAILED',
+      message: 'Failed to retrieve transaction status from Horizon.',
+    });
+  }
+
+  private isHorizonNotFoundError(error: unknown): boolean {
+    const err = error as { response?: { status?: number } };
+    return err?.response?.status === 404;
+  }
+
+  private isUnknownColumnError(error: { message?: string } | null | undefined): boolean {
+    const message = error?.message?.toLowerCase() ?? '';
+    return message.includes('column') && message.includes('does not exist');
+  }
+
+  private toSnakeCase(value: string): string {
+    return value
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .replace(/-/g, '_')
+      .toLowerCase();
+  }
+
+  private humanizeCode(code: string): string {
+    const sentence = code.replace(/_/g, ' ').trim();
+    return sentence.charAt(0).toUpperCase() + sentence.slice(1) + '.';
   }
 }

--- a/test/unit/modules/transactions/transactions.controller.spec.ts
+++ b/test/unit/modules/transactions/transactions.controller.spec.ts
@@ -1,0 +1,93 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TransactionsController } from '../../../../src/modules/transactions/transactions.controller';
+import { TransactionType } from '../../../../src/modules/transactions/dto/submit-transaction-request.dto';
+import { TransactionsService } from '../../../../src/modules/transactions/transactions.service';
+
+describe('TransactionsController', () => {
+  let controller: TransactionsController;
+  let transactionsService: TransactionsService;
+
+  const validWallet = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+  const validHash = 'a'.repeat(64);
+
+  const mockTransactionsService = {
+    submitTransaction: jest.fn(),
+    getTransactionStatus: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TransactionsController],
+      providers: [{ provide: TransactionsService, useValue: mockTransactionsService }],
+    }).compile();
+
+    controller = module.get<TransactionsController>(TransactionsController);
+    transactionsService = module.get<TransactionsService>(TransactionsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('submitTransaction', () => {
+    it('should wrap the submission response in the standard envelope', async () => {
+      const dto = { xdr: 'AAAAAg...', type: TransactionType.DEPOSIT };
+      const data = { transactionHash: validHash, status: 'pending' as const };
+      mockTransactionsService.submitTransaction.mockResolvedValue(data);
+
+      const result = await controller.submitTransaction({ wallet: validWallet }, dto);
+
+      expect(result).toEqual({
+        success: true,
+        data,
+        message: 'Transaction submitted successfully',
+      });
+      expect(transactionsService.submitTransaction).toHaveBeenCalledWith(validWallet, dto);
+    });
+  });
+
+  describe('getTransactionStatus', () => {
+    it('should return the public transaction lookup in the standard envelope', async () => {
+      const data = {
+        hash: validHash,
+        status: 'success' as const,
+        type: 'loan_repay',
+        result: {
+          ledger: 123,
+          operationCount: 1,
+          sourceAccount: validWallet,
+          feeCharged: '100',
+          memoType: 'none',
+          memo: null,
+          createdAt: '2026-03-23T05:15:30Z',
+        },
+        error: null,
+        submittedAt: '2026-03-23T05:15:00.000Z',
+        confirmedAt: '2026-03-23T05:15:30Z',
+        lastCheckedAt: '2026-03-23T05:16:00.000Z',
+      };
+      mockTransactionsService.getTransactionStatus.mockResolvedValue(data);
+
+      const result = await controller.getTransactionStatus(validHash);
+
+      expect(result).toEqual({
+        success: true,
+        data,
+        message: 'Transaction status retrieved successfully',
+      });
+      expect(transactionsService.getTransactionStatus).toHaveBeenCalledWith(validHash);
+    });
+
+    it('should reject invalid hashes before calling the service', async () => {
+      await expect(controller.getTransactionStatus('not-a-hash')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(transactionsService.getTransactionStatus).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/modules/transactions/transactions.service.spec.ts
+++ b/test/unit/modules/transactions/transactions.service.spec.ts
@@ -1,0 +1,293 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import {
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as StellarSdk from 'stellar-sdk';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { TransactionsService } from '../../../../src/modules/transactions/transactions.service';
+
+const mockTransactionCall = jest.fn();
+const mockIncludeFailed = jest.fn();
+const mockTransactionsBuilder = jest.fn();
+const mockSubmitTransaction = jest.fn();
+
+jest.mock('stellar-sdk', () => {
+  const actual = jest.requireActual('stellar-sdk');
+
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: jest.fn().mockImplementation(() => ({
+        submitTransaction: mockSubmitTransaction,
+        transactions: mockTransactionsBuilder,
+      })),
+    },
+  };
+});
+
+describe('TransactionsService', () => {
+  let service: TransactionsService;
+
+  const validWallet = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+  const validHash = 'a'.repeat(64);
+  const now = '2026-03-23T05:16:00.000Z';
+
+  const mockCacheManager = {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+
+  const mockSupabaseTable = {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+    eq: jest.fn(),
+    maybeSingle: jest.fn(),
+  };
+
+  const mockSupabaseClient = {
+    from: jest.fn().mockReturnValue(mockSupabaseTable),
+  };
+
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      if (key === 'STELLAR_HORIZON_URL') return 'https://horizon-testnet.stellar.org';
+      if (key === 'STELLAR_NETWORK_PASSPHRASE') return StellarSdk.Networks.TESTNET;
+      return undefined;
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    mockTransactionsBuilder.mockReturnValue({
+      includeFailed: mockIncludeFailed,
+      transaction: mockTransactionCall,
+    });
+    mockIncludeFailed.mockReturnValue({
+      transaction: mockTransactionCall,
+    });
+    mockTransactionCall.mockReturnValue({
+      call: jest.fn(),
+    });
+    mockSupabaseTable.insert.mockResolvedValue({ error: null });
+    mockSupabaseTable.update.mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionsService,
+        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    service = module.get<TransactionsService>(TransactionsService);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  function mockDbLookup(record: Record<string, unknown> | null) {
+    mockSupabaseTable.select.mockReturnThis();
+    mockSupabaseTable.eq.mockReturnThis();
+    mockSupabaseTable.maybeSingle.mockResolvedValue({ data: record, error: null });
+  }
+
+  function mockTxCallResult(result: unknown) {
+    const call = jest.fn().mockResolvedValue(result);
+    mockTransactionCall.mockReturnValue({ call });
+    return call;
+  }
+
+  it('should return finalized cached responses without calling Horizon', async () => {
+    mockCacheManager.get.mockResolvedValue({
+      hash: validHash,
+      status: 'success',
+      type: 'deposit',
+      result: {
+        ledger: 123,
+        operationCount: 1,
+        sourceAccount: validWallet,
+        feeCharged: '100',
+        memoType: 'none',
+        memo: null,
+        createdAt: '2026-03-23T05:15:30Z',
+      },
+      error: null,
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      confirmedAt: '2026-03-23T05:15:30Z',
+      lastCheckedAt: now,
+    });
+
+    const result = await service.getTransactionStatus(validHash);
+
+    expect(result.status).toBe('success');
+    expect(mockTransactionsBuilder).not.toHaveBeenCalled();
+  });
+
+  it('should return and cache a successful finalized transaction', async () => {
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockDbLookup({
+      hash: validHash,
+      type: 'loan_repay',
+      status: 'pending',
+      submitted_at: '2026-03-23T05:15:00.000Z',
+      completed_at: null,
+      updated_at: '2026-03-23T05:15:10.000Z',
+    });
+    mockTxCallResult({
+      hash: validHash,
+      successful: true,
+      ledger_attr: 123456,
+      operation_count: 2,
+      source_account: validWallet,
+      fee_charged: '100',
+      memo_type: 'text',
+      memo: 'Loan repayment',
+      created_at: '2026-03-23T05:15:30Z',
+    });
+
+    const result = await service.getTransactionStatus(validHash);
+
+    expect(result).toMatchObject({
+      hash: validHash,
+      status: 'success',
+      type: 'loan_repay',
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      confirmedAt: '2026-03-23T05:15:30Z',
+      result: {
+        ledger: 123456,
+        operationCount: 2,
+        sourceAccount: validWallet,
+      },
+      error: null,
+    });
+    expect(mockCacheManager.set).toHaveBeenCalledWith(
+      `transactions:status:${validHash}`,
+      expect.objectContaining({ status: 'success' }),
+      0,
+    );
+  });
+
+  it('should return pending when Horizon cannot find a locally tracked transaction yet', async () => {
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockDbLookup({
+      hash: validHash,
+      type: 'deposit',
+      status: 'pending',
+      submitted_at: '2026-03-23T05:15:00.000Z',
+      completed_at: null,
+      updated_at: '2026-03-23T05:15:10.000Z',
+    });
+    mockTxCallResult(
+      Promise.reject({
+        response: { status: 404 },
+      }),
+    );
+
+    const result = await service.getTransactionStatus(validHash);
+
+    expect(result).toEqual({
+      hash: validHash,
+      status: 'pending',
+      type: 'deposit',
+      result: null,
+      error: null,
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      confirmedAt: null,
+      lastCheckedAt: now,
+    });
+  });
+
+  it('should return 404 when Horizon cannot find an unknown hash', async () => {
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockDbLookup(null);
+    mockTxCallResult(
+      Promise.reject({
+        response: { status: 404 },
+      }),
+    );
+
+    await expect(service.getTransactionStatus(validHash)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should return 503 when Horizon is temporarily unavailable', async () => {
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockDbLookup({
+      hash: validHash,
+      type: 'deposit',
+      status: 'pending',
+      submitted_at: '2026-03-23T05:15:00.000Z',
+    });
+    mockTxCallResult(Promise.reject(new Error('network timeout')));
+
+    await expect(service.getTransactionStatus(validHash)).rejects.toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('should return failure details and cache finalized failed transactions', async () => {
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockDbLookup({
+      hash: validHash,
+      type: 'withdraw',
+      status: 'pending',
+      submitted_at: '2026-03-23T05:15:00.000Z',
+      completed_at: null,
+      updated_at: '2026-03-23T05:15:10.000Z',
+    });
+    mockTxCallResult({
+      hash: validHash,
+      successful: false,
+      result_xdr: 'AAAA',
+      ledger_attr: 123456,
+      operation_count: 1,
+      source_account: validWallet,
+      fee_charged: '100',
+      memo_type: 'none',
+      memo: undefined,
+      created_at: '2026-03-23T05:15:30Z',
+    });
+    jest.spyOn(StellarSdk.xdr.TransactionResult, 'fromXDR').mockReturnValue({
+      result: () => ({
+        switch: () => ({ name: 'txFailed' }),
+        value: () => [{ switch: () => ({ name: 'opUnderfunded' }) }],
+      }),
+    } as any);
+
+    const result = await service.getTransactionStatus(validHash);
+
+    expect(result).toMatchObject({
+      hash: validHash,
+      status: 'failed',
+      type: 'withdraw',
+      result: null,
+      error: {
+        code: 'tx_failed',
+        message:
+          'Insufficient balance to complete one or more operations in this transaction.',
+        operationCodes: ['op_underfunded'],
+      },
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      confirmedAt: '2026-03-23T05:15:30Z',
+    });
+    expect(mockCacheManager.set).toHaveBeenCalledWith(
+      `transactions:status:${validHash}`,
+      expect.objectContaining({ status: 'failed' }),
+      0,
+    );
+  });
+});


### PR DESCRIPTION
# Add public transaction status lookup endpoint

## 🔗 Related Issue
Closes #63

---

## 🔖 Title
Add public Horizon-backed transaction status lookup with finalized caching

---

## 📝 Description
This PR adds a public `GET /transactions/:hash` endpoint that queries Horizon for Stellar transaction details, normalizes the status to `pending`, `success`, or `failed`, and returns a comprehensive response for frontend polling.

It also caches finalized transaction results, preserves pending lookups without caching, and reads the local transaction type when available from the database.

---

## 🔄 Changes Made
- [x] Added `GET /transactions/:hash` as a public endpoint with 64-char hex hash validation
- [x] Implemented Horizon transaction lookup, status normalization, and success/failure parsing
- [x] Added finalized-result caching plus DB compatibility for both `hash` and `transaction_hash` schemas

---

## 🚀 API Usage Example

### Request
`GET /transactions/f3a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef12345678`

### Sample Response (Success)
```json
{
  "success": true,
  "data": {
    "hash": "f3a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef12345678",
    "status": "success",
    "type": "loan_repayment",
    "result": {
      "ledger": 123456,
      "operationCount": 1,
      "sourceAccount": "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
      "feeCharged": "100",
      "memoType": "text",
      "memo": "Loan Repay #42",
      "createdAt": "2026-03-23T05:15:30Z"
    },
    "error": null,
    "submittedAt": "2026-03-23T05:15:00.000Z",
    "confirmedAt": "2026-03-23T05:15:30Z",
    "lastCheckedAt": "2026-04-27T12:35:00.000Z"
  },
  "message": "Transaction status retrieved successfully"
}
```

---

## 📈 Testing
Unit tests have been executed covering all critical flows:
- [x] **Controller**: 64-character hex hash validation and standard response envelope wrapping.
- [x] **Service**: 
    - Cache hits for finalized transactions.
    - Successful transaction parsing (ledger, fees, memos).
    - Failure extraction from XDR (e.g., `tx_failed`, `op_underfunded`).
    - Graceful pending status handling (found in DB, 404 in Horizon).
    - Proper 404 handling for completely unknown hashes.
    - Horizon API resilience (503/Timeout handling).
- [x] **Execution**: `npm test test/unit/modules/transactions -- --runInBand`
    - **Result**: `Test Suites: 2 passed, 2 total | Tests: 10 passed, 10 total`

---

## 📸 Screenshots (if applicable)
N/A

---

## 🗒️ Additional Notes
`tsc --noEmit` confirms no new type errors were introduced. A pre-existing type error in `src/jobs/loan-payment-reminder/loan-payment-reminder.service.ts` regarding `utcOffset` in `RepeatOptions` remains, as it is outside the scope of this task.
