### PR TITLE
test: add liquidity unit and end-to-end lifecycle coverage

### DIFF
--- a/src/modules/liquidity/liquidity.service.ts
+++ b/src/modules/liquidity/liquidity.service.ts
@@ -21,6 +21,7 @@ const SUMMARY_CACHE_TTL = 60;
 const STROOPS = 10_000_000n;
 const SHARE_PRICE_BPS = 10_000n;
 const LP_FEE_RATIO = 0.85;
+const MIN_DEPOSIT_AMOUNT = 10;
 
 @Injectable()
 export class LiquidityService {
@@ -121,6 +122,13 @@ export class LiquidityService {
     wallet: string,
     dto: LiquidityDepositRequestDto,
   ): Promise<LiquidityDepositResponseDto> {
+    if (dto.amount < MIN_DEPOSIT_AMOUNT) {
+      throw new BadRequestException({
+        code: 'VALIDATION_MINIMUM_DEPOSIT',
+        message: `Minimum deposit amount is $${MIN_DEPOSIT_AMOUNT}.`,
+      });
+    }
+
     const amountInStroops = this.toStroops(dto.amount);
 
     const [poolStats, sharesReceived] = await Promise.all([

--- a/test/e2e/modules/liquidity/liquidity-flow.e2e-spec.ts
+++ b/test/e2e/modules/liquidity/liquidity-flow.e2e-spec.ts
@@ -1,0 +1,396 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidationPipe, UnauthorizedException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigModule } from '@nestjs/config';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { LiquidityModule } from '../../../../src/modules/liquidity/liquidity.module';
+import { TransactionsModule } from '../../../../src/modules/transactions/transactions.module';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { LiquidityContractClient } from '../../../../src/blockchain/contracts/liquidity-contract.client';
+import { TransactionsService } from '../../../../src/modules/transactions/transactions.service';
+import { JwtAuthGuard } from '../../../../src/common/guards/jwt-auth.guard';
+import { TransactionType } from '../../../../src/modules/transactions/dto/submit-transaction-request.dto';
+
+describe('Liquidity Operations Flow (e2e)', () => {
+  let app: NestFastifyApplication;
+
+  const validWallet = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+  const STROOPS = 10_000_000n;
+
+  const state = {
+    nowIso: '2026-04-28T11:00:00.000Z',
+    totalLiquidity: 1000n * STROOPS,
+    totalShares: 1000n * STROOPS,
+    availableLiquidity: 1000n * STROOPS,
+    lockedLiquidity: 0n,
+    withdrawalFeeBps: 50n,
+    userShares: 0n,
+    totalInvested: 0,
+    activeLoans: [{ loan_amount: 400, interest_rate: 8 }],
+    txByHash: new Map<
+      string,
+      {
+        type: TransactionType;
+        status: 'pending' | 'success';
+        depositAmount?: bigint;
+        depositShares?: bigint;
+        withdrawShares?: bigint;
+      }
+    >(),
+    submittedTxCount: 0,
+    pendingDepositAmount: 0n,
+    pendingDepositShares: 0n,
+    pendingWithdrawShares: 0n,
+  };
+
+  const mockCacheManager = {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+
+  const mockJwtAuthGuard = {
+    canActivate: jest.fn((context) => {
+      const req = context.switchToHttp().getRequest();
+      const authHeader = req.headers['authorization'];
+
+      if (!authHeader?.startsWith('Bearer ')) {
+        throw new UnauthorizedException('No token provided');
+      }
+
+      req.user = { wallet: validWallet };
+      return true;
+    }),
+  };
+
+  const mockLiquidityContractClient = {
+    getPoolStats: jest.fn(),
+    calculateDeposit: jest.fn(),
+    buildDepositTx: jest.fn(),
+    getLpShares: jest.fn(),
+    calculateWithdrawal: jest.fn(),
+    buildWithdrawTx: jest.fn(),
+  };
+
+  const mockTransactionsService = {
+    submitTransaction: jest.fn(),
+    getTransactionStatus: jest.fn(),
+  };
+
+  function createSupabaseLoansQuery() {
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ data: state.activeLoans, error: null }),
+    };
+  }
+
+  function createSupabasePositionsQuery() {
+    return {
+      select: jest.fn((columns?: string, options?: { count?: string; head?: boolean }) => {
+        if (options?.head) {
+          return Promise.resolve({ count: state.userShares > 0n ? 1 : 0, error: null });
+        }
+
+        if (columns === 'deposited_amount') {
+          return {
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: state.totalInvested > 0 ? { deposited_amount: state.totalInvested } : null,
+              error: state.totalInvested > 0 ? null : { message: 'not found' },
+            }),
+          };
+        }
+
+        return Promise.resolve({ data: [], error: null });
+      }),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: state.totalInvested > 0 ? { deposited_amount: state.totalInvested } : null,
+        error: state.totalInvested > 0 ? null : { message: 'not found' },
+      }),
+    };
+  }
+
+  const mockSupabaseClient = {
+    from: jest.fn((table: string) => {
+      if (table === 'loans') {
+        return createSupabaseLoansQuery();
+      }
+
+      if (table === 'liquidity_positions') {
+        return createSupabasePositionsQuery();
+      }
+
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+  };
+
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+    getClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  };
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true }), LiquidityModule, TransactionsModule],
+    })
+      .overrideProvider(CACHE_MANAGER)
+      .useValue(mockCacheManager)
+      .overrideProvider(SupabaseService)
+      .useValue(mockSupabaseService)
+      .overrideProvider(LiquidityContractClient)
+      .useValue(mockLiquidityContractClient)
+      .overrideProvider(TransactionsService)
+      .useValue(mockTransactionsService)
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state.totalLiquidity = 1000n * STROOPS;
+    state.totalShares = 1000n * STROOPS;
+    state.availableLiquidity = 1000n * STROOPS;
+    state.lockedLiquidity = 0n;
+    state.withdrawalFeeBps = 50n;
+    state.userShares = 0n;
+    state.totalInvested = 0;
+    state.activeLoans = [{ loan_amount: 400, interest_rate: 8 }];
+    state.txByHash.clear();
+    state.submittedTxCount = 0;
+    state.pendingDepositAmount = 0n;
+    state.pendingDepositShares = 0n;
+    state.pendingWithdrawShares = 0n;
+
+    mockCacheManager.get.mockResolvedValue(undefined);
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    mockLiquidityContractClient.getPoolStats.mockImplementation(async () => ({
+      totalLiquidity: state.totalLiquidity,
+      lockedLiquidity: state.lockedLiquidity,
+      availableLiquidity: state.availableLiquidity,
+      totalShares: state.totalShares,
+      sharePrice: state.totalShares > 0n ? (state.totalLiquidity * 10000n) / state.totalShares : 10000n,
+      withdrawalFeeBps: state.withdrawalFeeBps,
+    }));
+
+    mockLiquidityContractClient.calculateDeposit.mockImplementation(async (amountInStroops: bigint) => {
+      const shares =
+        state.totalShares <= 0n || state.totalLiquidity <= 0n
+          ? amountInStroops
+          : (amountInStroops * state.totalShares) / state.totalLiquidity;
+
+      state.pendingDepositAmount = amountInStroops;
+      state.pendingDepositShares = shares;
+      return shares;
+    });
+
+    mockLiquidityContractClient.buildDepositTx.mockResolvedValue('AAAAAgDEPOSIT...');
+
+    mockLiquidityContractClient.getLpShares.mockImplementation(async () => state.userShares);
+
+    mockLiquidityContractClient.calculateWithdrawal.mockImplementation(async (sharesInStroops: bigint) => {
+      if (state.totalShares <= 0n) {
+        return 0n;
+      }
+
+      return (sharesInStroops * state.totalLiquidity) / state.totalShares;
+    });
+
+    mockLiquidityContractClient.buildWithdrawTx.mockImplementation(async (_wallet, sharesInStroops: bigint) => {
+      state.pendingWithdrawShares = sharesInStroops;
+      return 'AAAAAgWITHDRAW...';
+    });
+
+    mockTransactionsService.submitTransaction.mockImplementation(async (_wallet, dto) => {
+      state.submittedTxCount += 1;
+      const hash = `${String(state.submittedTxCount).padStart(2, '0')}${'b'.repeat(62)}`;
+
+      state.txByHash.set(hash, {
+        type: dto.type,
+        status: 'pending',
+        depositAmount: dto.type === TransactionType.DEPOSIT ? state.pendingDepositAmount : undefined,
+        depositShares: dto.type === TransactionType.DEPOSIT ? state.pendingDepositShares : undefined,
+        withdrawShares: dto.type === TransactionType.WITHDRAW ? state.pendingWithdrawShares : undefined,
+      });
+
+      return { transactionHash: hash, status: 'pending' };
+    });
+
+    mockTransactionsService.getTransactionStatus.mockImplementation(async (hash: string) => {
+      const tx = state.txByHash.get(hash);
+      if (!tx) {
+        throw new Error('missing transaction');
+      }
+
+      tx.status = 'success';
+
+      if (tx.type === TransactionType.DEPOSIT && tx.depositAmount && tx.depositShares) {
+        state.totalLiquidity += tx.depositAmount;
+        state.availableLiquidity += tx.depositAmount;
+        state.totalShares += tx.depositShares;
+        state.userShares += tx.depositShares;
+        state.totalInvested += Number(tx.depositAmount) / Number(STROOPS);
+      }
+
+      if (tx.type === TransactionType.WITHDRAW && tx.withdrawShares) {
+        const gross =
+          state.totalShares > 0n ? (tx.withdrawShares * state.totalLiquidity) / state.totalShares : 0n;
+        state.totalLiquidity -= gross;
+        state.availableLiquidity -= gross;
+        state.totalShares -= tx.withdrawShares;
+        state.userShares -= tx.withdrawShares;
+      }
+
+      return {
+        hash,
+        status: 'success',
+        type: tx.type,
+        result: {
+          ledger: 23456,
+          operationCount: 1,
+          sourceAccount: validWallet,
+          feeCharged: '100',
+          memoType: 'none',
+          memo: null,
+          createdAt: state.nowIso,
+        },
+        error: null,
+        submittedAt: state.nowIso,
+        confirmedAt: state.nowIso,
+        lastCheckedAt: state.nowIso,
+      };
+    });
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+
+    state.txByHash.clear();
+  });
+
+  it('should execute complete liquidity flow: overview -> deposit -> submit -> confirm -> summary -> withdraw', async () => {
+    const overviewRes = await app.inject({ method: 'GET', url: '/liquidity/overview' });
+    expect(overviewRes.statusCode).toBe(200);
+
+    const overviewBody = JSON.parse(overviewRes.payload);
+    expect(overviewBody.data.apy).toBe(6.8);
+    expect(overviewBody.data.utilization).toBe(40);
+
+    const depositRes = await app.inject({
+      method: 'POST',
+      url: '/liquidity/deposit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 200 },
+    });
+
+    expect(depositRes.statusCode).toBe(200);
+
+    const submitDepositTxRes = await app.inject({
+      method: 'POST',
+      url: '/transactions/submit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { xdr: 'AAAAAgDEPOSIT...', type: TransactionType.DEPOSIT },
+    });
+
+    expect(submitDepositTxRes.statusCode).toBe(200);
+    const submitDepositTxBody = JSON.parse(submitDepositTxRes.payload);
+
+    const confirmDepositTxRes = await app.inject({
+      method: 'GET',
+      url: `/transactions/${submitDepositTxBody.data.transactionHash}`,
+    });
+
+    expect(confirmDepositTxRes.statusCode).toBe(200);
+    expect(state.userShares).toBeGreaterThan(0n);
+
+    const summaryAfterDepositRes = await app.inject({
+      method: 'GET',
+      url: '/liquidity/my-summary',
+      headers: { authorization: 'Bearer test.jwt' },
+    });
+
+    expect(summaryAfterDepositRes.statusCode).toBe(200);
+    const summaryAfterDepositBody = JSON.parse(summaryAfterDepositRes.payload);
+    expect(summaryAfterDepositBody.data.totalInvested).toBe(200);
+    expect(summaryAfterDepositBody.data.shares).toBe(200);
+
+    const withdrawRes = await app.inject({
+      method: 'POST',
+      url: '/liquidity/withdraw',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { shares: 100 },
+    });
+
+    expect(withdrawRes.statusCode).toBe(200);
+
+    const submitWithdrawTxRes = await app.inject({
+      method: 'POST',
+      url: '/transactions/submit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { xdr: 'AAAAAgWITHDRAW...', type: TransactionType.WITHDRAW },
+    });
+
+    expect(submitWithdrawTxRes.statusCode).toBe(200);
+    const submitWithdrawTxBody = JSON.parse(submitWithdrawTxRes.payload);
+
+    const confirmWithdrawTxRes = await app.inject({
+      method: 'GET',
+      url: `/transactions/${submitWithdrawTxBody.data.transactionHash}`,
+    });
+
+    expect(confirmWithdrawTxRes.statusCode).toBe(200);
+
+    const summaryAfterWithdrawRes = await app.inject({
+      method: 'GET',
+      url: '/liquidity/my-summary',
+      headers: { authorization: 'Bearer test.jwt' },
+    });
+
+    expect(summaryAfterWithdrawRes.statusCode).toBe(200);
+    const summaryAfterWithdrawBody = JSON.parse(summaryAfterWithdrawRes.payload);
+    expect(summaryAfterWithdrawBody.data.shares).toBe(100);
+    expect(summaryAfterWithdrawBody.data.activeLoans).toBe(1);
+  });
+
+  it('should validate minimum deposit and insufficient shares errors', async () => {
+    const belowMinDepositRes = await app.inject({
+      method: 'POST',
+      url: '/liquidity/deposit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 5 },
+    });
+
+    expect(belowMinDepositRes.statusCode).toBe(400);
+
+    const excessiveWithdrawRes = await app.inject({
+      method: 'POST',
+      url: '/liquidity/withdraw',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { shares: 10 },
+    });
+
+    expect(excessiveWithdrawRes.statusCode).toBe(400);
+  });
+});

--- a/test/e2e/modules/loans/loan-lifecycle.e2e-spec.ts
+++ b/test/e2e/modules/loans/loan-lifecycle.e2e-spec.ts
@@ -1,0 +1,491 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidationPipe, UnauthorizedException } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { LoansModule } from '../../../../src/modules/loans/loans.module';
+import { TransactionsModule } from '../../../../src/modules/transactions/transactions.module';
+import { ReputationService } from '../../../../src/modules/reputation/reputation.service';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { CreditLineContractClient } from '../../../../src/blockchain/contracts/credit-line-contract.client';
+import { ReputationContractClient } from '../../../../src/blockchain/contracts/reputation-contract.client';
+import { TransactionsService } from '../../../../src/modules/transactions/transactions.service';
+import { JwtAuthGuard } from '../../../../src/common/guards/jwt-auth.guard';
+import { TransactionType } from '../../../../src/modules/transactions/dto/submit-transaction-request.dto';
+
+type LoanStatus = 'pending' | 'active' | 'completed' | 'defaulted';
+
+type LoanRow = {
+  id: string;
+  loan_id: string;
+  user_wallet: string;
+  merchant_id: string;
+  amount: number;
+  loan_amount: number;
+  guarantee: number;
+  interest_rate: number;
+  total_repayment: number;
+  remaining_balance: number;
+  term: number;
+  status: LoanStatus;
+  next_payment_due: string | null;
+  created_at: string;
+  completed_at: string | null;
+  defaulted_at: string | null;
+};
+
+describe('Loan Lifecycle Flow (e2e)', () => {
+  let app: NestFastifyApplication;
+
+  const validWallet = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+  const merchantId = 'a1b2c3d4-e5f6-4890-abcd-ef1234567890';
+
+  const state = {
+    nowIso: '2026-04-28T10:00:00.000Z',
+    merchantActive: true,
+    maxCredit: 3000,
+    score: 75,
+    interestRate: 8,
+    loans: [] as LoanRow[],
+    txToLoanId: new Map<string, string>(),
+    txByHash: new Map<string, { type: TransactionType; status: 'pending' | 'success' }>(),
+    submittedTxCount: 0,
+  };
+
+  const mockJwtAuthGuard = {
+    canActivate: jest.fn((context) => {
+      const req = context.switchToHttp().getRequest();
+      const authHeader = req.headers['authorization'];
+
+      if (!authHeader?.startsWith('Bearer ')) {
+        throw new UnauthorizedException('No token provided');
+      }
+
+      req.user = { wallet: validWallet };
+      return true;
+    }),
+  };
+
+  const mockReputationService = {
+    getReputationScore: jest.fn(),
+  };
+
+  const mockReputationContractClient = {
+    getScore: jest.fn(),
+  };
+
+  const mockCreditLineContract = {
+    buildCreateLoanTransaction: jest.fn(),
+    buildRepayLoanTx: jest.fn(),
+  };
+
+  const mockTransactionsService = {
+    submitTransaction: jest.fn(),
+    getTransactionStatus: jest.fn(),
+  };
+
+  function buildSupabaseQuery(table: string) {
+    if (table === 'merchants') {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: state.merchantActive
+            ? { id: merchantId, name: 'TechStore', is_active: true }
+            : { id: merchantId, name: 'TechStore', is_active: false },
+          error: null,
+        }),
+      };
+    }
+
+    if (table === 'loans') {
+      const queryState: {
+        filters: Record<string, unknown>;
+        selected: string;
+        listStatuses: string[] | null;
+      } = {
+        filters: {},
+        selected: '',
+        listStatuses: null,
+      };
+
+      const query = {
+        select: jest.fn((columns: string) => {
+          queryState.selected = columns;
+          return query;
+        }),
+        eq: jest.fn((column: string, value: unknown) => {
+          queryState.filters[column] = value;
+          return query;
+        }),
+        in: jest.fn((column: string, values: string[]) => {
+          if (column === 'status') {
+            queryState.listStatuses = values;
+          }
+
+          return Promise.resolve({
+            data: state.loans
+              .filter((loan) => loan.user_wallet === validWallet)
+              .filter((loan) =>
+                queryState.listStatuses ? queryState.listStatuses.includes(loan.status) : true,
+              )
+              .map((loan) => ({
+                ...loan,
+                merchants: {
+                  id: merchantId,
+                  name: 'TechStore',
+                  logo: 'https://cdn.trustup.app/techstore.png',
+                },
+                loan_payments: loan.status === 'completed' ? [{ amount: loan.total_repayment }] : [],
+              })),
+            error: null,
+            count: state.loans.filter((loan) =>
+              queryState.listStatuses ? queryState.listStatuses.includes(loan.status) : true,
+            ).length,
+          });
+        }),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockReturnThis(),
+        single: jest.fn().mockImplementation(async () => {
+          if (queryState.selected.includes('remaining_balance') && queryState.filters.id) {
+            const loan = state.loans.find((item) => item.id === queryState.filters.id);
+            return { data: loan ?? null, error: loan ? null : { message: 'not found' } };
+          }
+
+          if (queryState.selected.includes('id, name, is_active')) {
+            return {
+              data: state.merchantActive
+                ? { id: merchantId, name: 'TechStore', is_active: true }
+                : { id: merchantId, name: 'TechStore', is_active: false },
+              error: null,
+            };
+          }
+
+          return { data: null, error: null };
+        }),
+        insert: jest.fn().mockImplementation(async (payload: Partial<LoanRow>) => {
+          const newLoan: LoanRow = {
+            id: `11111111-2222-3333-4444-${String(state.loans.length + 1).padStart(12, '0')}`,
+            loan_id: String(payload.loan_id),
+            user_wallet: String(payload.user_wallet),
+            merchant_id: String(payload.merchant_id),
+            amount: Number(payload.amount),
+            loan_amount: Number(payload.loan_amount),
+            guarantee: Number(payload.guarantee),
+            interest_rate: Number(payload.interest_rate),
+            total_repayment: Number(payload.total_repayment),
+            remaining_balance: Number(payload.remaining_balance),
+            term: Number(payload.term),
+            status: 'pending',
+            next_payment_due: (payload.next_payment_due as string) ?? null,
+            created_at: state.nowIso,
+            completed_at: null,
+            defaulted_at: null,
+          };
+
+          state.loans.push(newLoan);
+          return { error: null };
+        }),
+        then: undefined as unknown,
+      };
+
+      query.then = ((resolve: (value: unknown) => unknown) => {
+        const data = state.loans
+          .filter((loan) => loan.user_wallet === queryState.filters.user_wallet)
+          .filter((loan) => {
+            const statusFilter = queryState.filters.status;
+            return statusFilter ? loan.status === statusFilter : true;
+          })
+          .map((loan) => {
+            if (queryState.selected.includes('remaining_balance') && !queryState.selected.includes('id,')) {
+              return { remaining_balance: loan.remaining_balance };
+            }
+
+            return loan;
+          });
+
+        return Promise.resolve(resolve({ data, error: null, count: data.length }));
+      }) as unknown as undefined;
+
+      return query;
+    }
+
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      insert: jest.fn().mockResolvedValue({ error: null }),
+      in: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+    };
+  }
+
+  const mockSupabaseClient = {
+    from: jest.fn((table: string) => buildSupabaseQuery(table)),
+  };
+
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+    getClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  };
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true }), LoansModule, TransactionsModule],
+    })
+      .overrideProvider(SupabaseService)
+      .useValue(mockSupabaseService)
+      .overrideProvider(ReputationService)
+      .useValue(mockReputationService)
+      .overrideProvider(ReputationContractClient)
+      .useValue(mockReputationContractClient)
+      .overrideProvider(CreditLineContractClient)
+      .useValue(mockCreditLineContract)
+      .overrideProvider(TransactionsService)
+      .useValue(mockTransactionsService)
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state.merchantActive = true;
+    state.maxCredit = 3000;
+    state.score = 75;
+    state.interestRate = 8;
+    state.loans = [];
+    state.txToLoanId.clear();
+    state.txByHash.clear();
+    state.submittedTxCount = 0;
+
+    mockReputationService.getReputationScore.mockResolvedValue({
+      wallet: validWallet,
+      score: state.score,
+      tier: 'silver',
+      interestRate: state.interestRate,
+      maxCredit: state.maxCredit,
+      lastUpdated: '2026-04-28T09:59:00.000Z',
+    });
+
+    mockReputationContractClient.getScore.mockResolvedValue(state.score);
+
+    mockCreditLineContract.buildCreateLoanTransaction.mockImplementation(async (_wallet, payload) => {
+      return `xdr-loan-create-${payload.loanId}`;
+    });
+
+    mockCreditLineContract.buildRepayLoanTx.mockImplementation(async (_wallet, loanId, amount) => {
+      return `xdr-loan-repay-${loanId}-${amount}`;
+    });
+
+    mockTransactionsService.submitTransaction.mockImplementation(async (_wallet, dto) => {
+      state.submittedTxCount += 1;
+      const hash = `${String(state.submittedTxCount).padStart(2, '0')}${'a'.repeat(62)}`;
+      state.txByHash.set(hash, { type: dto.type, status: 'pending' });
+
+      if (dto.type === TransactionType.LOAN_CREATE) {
+        const pendingLoan = state.loans[state.loans.length - 1];
+        if (pendingLoan) {
+          state.txToLoanId.set(hash, pendingLoan.id);
+        }
+      }
+
+      if (dto.type === TransactionType.LOAN_REPAY) {
+        const activeLoan = state.loans.find((loan) => loan.status === 'active');
+        if (activeLoan) {
+          state.txToLoanId.set(hash, activeLoan.id);
+        }
+      }
+
+      return { transactionHash: hash, status: 'pending' };
+    });
+
+    mockTransactionsService.getTransactionStatus.mockImplementation(async (hash: string) => {
+      const tx = state.txByHash.get(hash);
+      if (!tx) {
+        throw new Error('missing transaction');
+      }
+
+      tx.status = 'success';
+      const linkedLoanId = state.txToLoanId.get(hash);
+      if (linkedLoanId) {
+        const loan = state.loans.find((item) => item.id === linkedLoanId);
+
+        if (loan && tx.type === TransactionType.LOAN_CREATE) {
+          loan.status = 'active';
+        }
+
+        if (loan && tx.type === TransactionType.LOAN_REPAY) {
+          loan.remaining_balance = 0;
+          loan.status = 'completed';
+          loan.completed_at = state.nowIso;
+        }
+      }
+
+      return {
+        hash,
+        status: 'success',
+        type: tx.type,
+        result: {
+          ledger: 12345,
+          operationCount: 1,
+          sourceAccount: validWallet,
+          feeCharged: '100',
+          memoType: 'none',
+          memo: null,
+          createdAt: state.nowIso,
+        },
+        error: null,
+        submittedAt: state.nowIso,
+        confirmedAt: state.nowIso,
+        lastCheckedAt: state.nowIso,
+      };
+    });
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+
+    state.loans = [];
+    state.txByHash.clear();
+    state.txToLoanId.clear();
+  });
+
+  it('should execute complete loan lifecycle: quote -> create -> submit -> confirm -> list -> repay -> complete', async () => {
+    const quoteRes = await app.inject({
+      method: 'POST',
+      url: '/loans/quote',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 500, merchant: merchantId, term: 4 },
+    });
+
+    expect(quoteRes.statusCode).toBe(200);
+
+    const availableCreditRes = await app.inject({
+      method: 'GET',
+      url: '/loans/available-credit',
+      headers: { authorization: 'Bearer test.jwt' },
+    });
+
+    expect(availableCreditRes.statusCode).toBe(200);
+    expect(JSON.parse(availableCreditRes.payload).data.availableCredit).toBe(3000);
+
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/loans/create',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 500, merchant: merchantId, term: 4 },
+    });
+
+    expect(createRes.statusCode).toBe(200);
+    expect(state.loans).toHaveLength(1);
+    expect(state.loans[0].status).toBe('pending');
+
+    const submitCreateTxRes = await app.inject({
+      method: 'POST',
+      url: '/transactions/submit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { xdr: 'AAAAAgLOANCREATE...', type: TransactionType.LOAN_CREATE },
+    });
+
+    expect(submitCreateTxRes.statusCode).toBe(200);
+    const submitCreateTxBody = JSON.parse(submitCreateTxRes.payload);
+
+    const confirmCreateTxRes = await app.inject({
+      method: 'GET',
+      url: `/transactions/${submitCreateTxBody.data.transactionHash}`,
+    });
+
+    expect(confirmCreateTxRes.statusCode).toBe(200);
+    expect(state.loans[0].status).toBe('active');
+
+    const listLoansRes = await app.inject({
+      method: 'GET',
+      url: '/loans/my-loans',
+      headers: { authorization: 'Bearer test.jwt' },
+    });
+
+    expect(listLoansRes.statusCode).toBe(200);
+    const listLoansBody = JSON.parse(listLoansRes.payload);
+    expect(listLoansBody.data).toHaveLength(1);
+    expect(listLoansBody.data[0].status).toBe('active');
+
+    const repayRes = await app.inject({
+      method: 'POST',
+      url: `/loans/${listLoansBody.data[0].id}/pay`,
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 410.67 },
+    });
+
+    expect(repayRes.statusCode).toBe(200);
+
+    const submitRepayTxRes = await app.inject({
+      method: 'POST',
+      url: '/transactions/submit',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { xdr: 'AAAAAgLOANREPAY...', type: TransactionType.LOAN_REPAY },
+    });
+
+    expect(submitRepayTxRes.statusCode).toBe(200);
+    const submitRepayTxBody = JSON.parse(submitRepayTxRes.payload);
+
+    const confirmRepayTxRes = await app.inject({
+      method: 'GET',
+      url: `/transactions/${submitRepayTxBody.data.transactionHash}`,
+    });
+
+    expect(confirmRepayTxRes.statusCode).toBe(200);
+    expect(state.loans[0].status).toBe('completed');
+    expect(state.loans[0].remaining_balance).toBe(0);
+  });
+
+  it('should validate inactive merchant and insufficient credit errors', async () => {
+    state.merchantActive = false;
+
+    const inactiveMerchantRes = await app.inject({
+      method: 'POST',
+      url: '/loans/quote',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 500, merchant: merchantId, term: 4 },
+    });
+
+    expect(inactiveMerchantRes.statusCode).toBe(400);
+
+    state.merchantActive = true;
+    state.maxCredit = 100;
+    mockReputationService.getReputationScore.mockResolvedValue({
+      wallet: validWallet,
+      score: state.score,
+      tier: 'silver',
+      interestRate: state.interestRate,
+      maxCredit: state.maxCredit,
+      lastUpdated: '2026-04-28T09:59:00.000Z',
+    });
+
+    const lowCreditRes = await app.inject({
+      method: 'POST',
+      url: '/loans/create',
+      headers: { authorization: 'Bearer test.jwt' },
+      payload: { amount: 500, merchant: merchantId, term: 4 },
+    });
+
+    expect(lowCreditRes.statusCode).toBe(400);
+  });
+});

--- a/test/unit/modules/liquidity/liquidity.service.spec.ts
+++ b/test/unit/modules/liquidity/liquidity.service.spec.ts
@@ -16,6 +16,16 @@ describe('LiquidityService', () => {
     set: jest.fn(),
   };
 
+  const mockSupabaseFrom = {
+    select: jest.fn(),
+    eq: jest.fn(),
+    single: jest.fn(),
+  };
+
+  const mockSupabaseClient = {
+    from: jest.fn(),
+  };
+
   const mockSupabaseService = {
     getServiceRoleClient: jest.fn(),
   };
@@ -25,6 +35,8 @@ describe('LiquidityService', () => {
     getPoolStats: jest.fn(),
     calculateWithdrawal: jest.fn(),
     buildWithdrawTx: jest.fn(),
+    calculateDeposit: jest.fn(),
+    buildDepositTx: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -39,10 +51,113 @@ describe('LiquidityService', () => {
 
     service = module.get<LiquidityService>(LiquidityService);
     jest.clearAllMocks();
+
+    mockSupabaseService.getServiceRoleClient.mockReturnValue(mockSupabaseClient);
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === 'loans') {
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockResolvedValue({
+            data: [
+              { loan_amount: 800, interest_rate: 8 },
+              { loan_amount: 200, interest_rate: 10 },
+            ],
+            error: null,
+          }),
+        };
+      }
+
+      if (table === 'liquidity_positions') {
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: { deposited_amount: 1000 },
+            error: null,
+          }),
+        };
+      }
+
+      return mockSupabaseFrom;
+    });
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('depositLiquidity', () => {
+    it('should build a deposit transaction and preview', async () => {
+      mockLiquidityContractClient.getPoolStats.mockResolvedValue({
+        totalLiquidity: 100000n * STROOPS,
+        lockedLiquidity: 90000n * STROOPS,
+        availableLiquidity: 10000n * STROOPS,
+        totalShares: 95000n * STROOPS,
+        sharePrice: 10500n,
+        withdrawalFeeBps: 50n,
+      });
+      mockLiquidityContractClient.calculateDeposit.mockResolvedValue(4761904761n);
+      mockLiquidityContractClient.buildDepositTx.mockResolvedValue('AAAAAgDEPOSIT...');
+
+      const result = await service.depositLiquidity(validWallet, { amount: 500 });
+
+      expect(result).toEqual({
+        unsignedXdr: 'AAAAAgDEPOSIT...',
+        description: 'Deposit $500 into liquidity pool',
+        preview: {
+          depositAmount: 500,
+          sharesReceived: 476.1904761,
+          currentSharePrice: 1.05,
+          newTotalValue: 100500,
+          currentTotalLiquidity: 100000,
+        },
+      });
+      expect(mockLiquidityContractClient.buildDepositTx).toHaveBeenCalledWith(
+        validWallet,
+        500n * STROOPS,
+      );
+    });
+
+    it('should default share price to 1 for the first deposit', async () => {
+      mockLiquidityContractClient.getPoolStats.mockResolvedValue({
+        totalLiquidity: 0n,
+        lockedLiquidity: 0n,
+        availableLiquidity: 0n,
+        totalShares: 0n,
+        sharePrice: 0n,
+        withdrawalFeeBps: 0n,
+      });
+      mockLiquidityContractClient.calculateDeposit.mockResolvedValue(100n * STROOPS);
+      mockLiquidityContractClient.buildDepositTx.mockResolvedValue('AAAAAgDEPOSIT...');
+
+      const result = await service.depositLiquidity(validWallet, { amount: 100 });
+
+      expect(result.preview.currentSharePrice).toBe(1);
+      expect(result.preview.sharesReceived).toBe(100);
+      expect(result.preview.currentTotalLiquidity).toBe(0);
+    });
+
+    it('should reject deposit amounts below minimum threshold', async () => {
+      await expect(service.depositLiquidity(validWallet, { amount: 9.99 })).rejects.toThrow(
+        BadRequestException,
+      );
+
+      await expect(service.depositLiquidity(validWallet, { amount: 9.99 })).rejects.toMatchObject({
+        response: {
+          code: 'VALIDATION_MINIMUM_DEPOSIT',
+        },
+      });
+
+      expect(mockLiquidityContractClient.getPoolStats).not.toHaveBeenCalled();
+    });
+
+    it('should surface pool read errors from contract client', async () => {
+      mockLiquidityContractClient.getPoolStats.mockRejectedValue(new Error('pool unavailable'));
+
+      await expect(service.depositLiquidity(validWallet, { amount: 200 })).rejects.toThrow(
+        'pool unavailable',
+      );
+    });
   });
 
   describe('withdrawLiquidity', () => {
@@ -155,6 +270,216 @@ describe('LiquidityService', () => {
       expect(result.preview.fee).toBe(0);
       expect(result.preview.netAmount).toBe(250.5);
       expect(result.preview.remainingShares).toBe(749.5);
+    });
+  });
+
+  describe('getPoolOverview', () => {
+    it('should compute overview metrics from contract and database state', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined);
+      mockLiquidityContractClient.getPoolStats.mockResolvedValue({
+        totalLiquidity: 2000n * STROOPS,
+        lockedLiquidity: 500n * STROOPS,
+        availableLiquidity: 1500n * STROOPS,
+        totalShares: 1800n * STROOPS,
+        sharePrice: 11111n,
+        withdrawalFeeBps: 50n,
+      });
+
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'loans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { loan_amount: 800, interest_rate: 8 },
+                { loan_amount: 200, interest_rate: 10 },
+              ],
+              error: null,
+            }),
+          };
+        }
+
+        if (table === 'liquidity_positions') {
+          return {
+            select: jest.fn().mockResolvedValue({ count: 4, error: null }),
+          };
+        }
+
+        return mockSupabaseFrom;
+      });
+
+      const result = await service.getPoolOverview();
+
+      expect(result).toEqual({
+        totalLiquidity: 2000,
+        apy: 7.14,
+        utilization: 50,
+        totalInvestors: 4,
+        activeLoans: 2,
+      });
+      expect(mockCacheManager.set).toHaveBeenCalledWith('liquidity:overview', result, 60);
+    });
+
+    it('should use contract fallback and return zero utilization when pool stats fail', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined);
+      mockLiquidityContractClient.getPoolStats.mockRejectedValue(new Error('rpc down'));
+
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'loans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          };
+        }
+
+        if (table === 'liquidity_positions') {
+          return {
+            select: jest.fn().mockResolvedValue({ count: 0, error: null }),
+          };
+        }
+
+        return mockSupabaseFrom;
+      });
+
+      const result = await service.getPoolOverview();
+
+      expect(result.totalLiquidity).toBe(0);
+      expect(result.utilization).toBe(0);
+      expect(result.apy).toBe(0);
+      expect(result.activeLoans).toBe(0);
+    });
+  });
+
+  describe('getInvestmentSummary', () => {
+    it('should return cached summary without querying blockchain or database', async () => {
+      const cached = {
+        totalInvested: 1000,
+        currentValue: 1085,
+        earnings: 85,
+        earningsPercent: 8.5,
+        apy: 9,
+        poolSize: 120000,
+        activeLoans: 8,
+        shares: 1000,
+      };
+      mockCacheManager.get.mockResolvedValue(cached);
+
+      const result = await service.getInvestmentSummary(validWallet);
+
+      expect(result).toEqual(cached);
+      expect(mockLiquidityContractClient.getLpShares).not.toHaveBeenCalled();
+      expect(mockSupabaseService.getServiceRoleClient).not.toHaveBeenCalled();
+    });
+
+    it('should compute earnings and percentage from pool and deposit data', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined);
+      mockLiquidityContractClient.getLpShares.mockResolvedValue(1000n * STROOPS);
+      mockLiquidityContractClient.calculateWithdrawal.mockResolvedValue(1100n * STROOPS);
+      mockLiquidityContractClient.getPoolStats.mockResolvedValue({
+        totalLiquidity: 2000n * STROOPS,
+        lockedLiquidity: 700n * STROOPS,
+        availableLiquidity: 1300n * STROOPS,
+        totalShares: 1800n * STROOPS,
+        sharePrice: 11111n,
+        withdrawalFeeBps: 50n,
+      });
+
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'liquidity_positions') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { deposited_amount: 1000 },
+              error: null,
+            }),
+          };
+        }
+
+        if (table === 'loans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { loan_amount: 300, interest_rate: 8 },
+                { loan_amount: 100, interest_rate: 10 },
+              ],
+              error: null,
+            }),
+          };
+        }
+
+        return mockSupabaseFrom;
+      });
+
+      const result = await service.getInvestmentSummary(validWallet);
+
+      expect(result).toEqual({
+        totalInvested: 1000,
+        currentValue: 1100,
+        earnings: 100,
+        earningsPercent: 10,
+        apy: 7.23,
+        poolSize: 2000,
+        activeLoans: 2,
+        shares: 1000,
+      });
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        `liquidity:summary:${validWallet}`,
+        result,
+        60,
+      );
+    });
+
+    it('should return zeroed values when user has no deposits and no active loans', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined);
+      mockLiquidityContractClient.getLpShares.mockResolvedValue(0n);
+      mockLiquidityContractClient.getPoolStats.mockResolvedValue({
+        totalLiquidity: 0n,
+        lockedLiquidity: 0n,
+        availableLiquidity: 0n,
+        totalShares: 0n,
+        sharePrice: 0n,
+        withdrawalFeeBps: 0n,
+      });
+
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'liquidity_positions') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'not found' },
+            }),
+          };
+        }
+
+        if (table === 'loans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          };
+        }
+
+        return mockSupabaseFrom;
+      });
+
+      const result = await service.getInvestmentSummary(validWallet);
+
+      expect(result.totalInvested).toBe(0);
+      expect(result.currentValue).toBe(0);
+      expect(result.earnings).toBe(0);
+      expect(result.earningsPercent).toBe(0);
+      expect(result.apy).toBe(0);
+      expect(result.activeLoans).toBe(0);
+      expect(result.shares).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds comprehensive automated coverage for liquidity unit behavior and end-to-end lifecycle flows for loans and liquidity operations.

## Issues
Closes #72
Closes #77
Closes #78
Closes #67

## What was implemented
- Added a full Loan Lifecycle E2E suite covering:
  - `POST /loans/quote`
  - `GET /loans/available-credit`
  - `POST /loans/create`
  - `POST /transactions/submit` (loan create + repay)
  - `GET /transactions/:hash`
  - `GET /loans/my-loans`
  - `POST /loans/:loanId/pay`
  - Full flow: quote -> create -> submit -> confirm -> list -> repay -> complete
  - Validation errors: inactive merchant, insufficient credit
  - Database-like state transitions validated in test state: pending -> active -> completed
  - Test cleanup in `afterAll`

- Added a full Liquidity Operations E2E suite covering:
  - `GET /liquidity/overview`
  - `POST /liquidity/deposit`
  - `POST /transactions/submit` (deposit + withdraw)
  - `GET /liquidity/my-summary`
  - `POST /liquidity/withdraw`
  - Full flow: overview -> deposit -> submit -> confirm -> summary -> withdraw
  - Validation errors: minimum deposit, insufficient shares
  - APY/utilization/summary expectations validated
  - State updates validated for deposit and withdrawal effects
  - Test cleanup in `afterAll`

- Expanded LiquidityService unit coverage for:
  - Deposit XDR building and first-deposit share-price behavior
  - Minimum deposit validation
  - Pool unavailability handling
  - Withdrawal logic and liquidity constraints
  - Pool overview metric computation and fallback behavior
  - Investment summary calculations (earnings and earnings %)
  - Cache-hit behavior verification

- Hardened LiquidityService with explicit minimum deposit guard (`VALIDATION_MINIMUM_DEPOSIT`) to enforce service-level validation independently from DTOs.

## Mocking strategy
- Soroban/contract interactions are fully mocked in tests (`CreditLineContractClient`, `LiquidityContractClient`, `TransactionsService`).
- Supabase calls are mocked with in-memory query behavior to verify endpoint flow and state transitions predictably.

## Test commands run
- `pnpm test -- test/unit/modules/liquidity/liquidity.service.spec.ts --runInBand`
- `pnpm test:e2e -- test/e2e/modules/loans/loan-lifecycle.e2e-spec.ts --runInBand`
- `pnpm test:e2e -- test/e2e/modules/liquidity/liquidity-flow.e2e-spec.ts --runInBand`

All above commands pass.

## Notes for meta issue #67
- This PR completes the LiquidityService unit coverage sub-issue (#72).
- #67 remains open until all remaining sub-issues (#69-#75) are completed and project-wide coverage target is met.
