### PR TITLE
Feat notifications service unit tests

### DIFF
--- a/src/modules/notifications/dto/notification-list-query.dto.ts
+++ b/src/modules/notifications/dto/notification-list-query.dto.ts
@@ -1,6 +1,23 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
+import {
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
+import type { NotificationType } from './notification-list-response.dto';
+
+const notificationTypes: NotificationType[] = [
+  'loan_reminder',
+  'loan_overdue',
+  'loan_completed',
+  'reputation_changed',
+  'liquidity_deposited',
+  'liquidity_withdrawn',
+];
 
 export class NotificationListQueryDto {
   @ApiPropertyOptional({
@@ -15,6 +32,15 @@ export class NotificationListQueryDto {
   })
   @IsBoolean()
   unread?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Filter notifications by type',
+    enum: notificationTypes,
+    example: 'loan_reminder',
+  })
+  @IsOptional()
+  @IsIn(notificationTypes)
+  type?: NotificationType;
 
   @ApiPropertyOptional({
     description: 'Maximum number of notifications to return',

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { SupabaseService } from '../../database/supabase.client';
 import { NotificationListQueryDto } from './dto/notification-list-query.dto';
 import {
@@ -23,7 +28,9 @@ export class NotificationsService {
 
     let notificationsQuery = client
       .from('notifications')
-      .select('id, type, title, message, data, is_read, created_at, read_at', { count: 'exact' })
+      .select('id, type, title, message, data, is_read, created_at, read_at', {
+        count: 'exact',
+      })
       .eq('user_wallet', wallet)
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
@@ -32,10 +39,16 @@ export class NotificationsService {
       notificationsQuery = notificationsQuery.eq('is_read', false);
     }
 
+    if (query.type) {
+      notificationsQuery = notificationsQuery.eq('type', query.type);
+    }
+
     const { data: notifications, error, count } = await notificationsQuery;
 
     if (error) {
-      this.logger.error(`Failed to fetch notifications for ${wallet}: ${error.message}`);
+      this.logger.error(
+        `Failed to fetch notifications for ${wallet}: ${error.message}`,
+      );
       throw new Error(error.message);
     }
 
@@ -46,7 +59,9 @@ export class NotificationsService {
       .eq('is_read', false);
 
     if (unreadError) {
-      this.logger.error(`Failed to fetch unread count for ${wallet}: ${unreadError.message}`);
+      this.logger.error(
+        `Failed to fetch unread count for ${wallet}: ${unreadError.message}`,
+      );
       throw new Error(unreadError.message);
     }
 
@@ -72,7 +87,10 @@ export class NotificationsService {
     };
   }
 
-  async markAsRead(wallet: string, notificationId: string): Promise<MarkAsReadResponseDto> {
+  async markAsRead(
+    wallet: string,
+    notificationId: string,
+  ): Promise<MarkAsReadResponseDto> {
     const client = this.supabaseService.getServiceRoleClient();
 
     const { data: notification, error: fetchError } = await client
@@ -106,7 +124,9 @@ export class NotificationsService {
       .eq('id', notificationId);
 
     if (updateError) {
-      this.logger.error(`Failed to mark notification ${notificationId} as read: ${updateError.message}`);
+      this.logger.error(
+        `Failed to mark notification ${notificationId} as read: ${updateError.message}`,
+      );
       throw new Error(updateError.message);
     }
 
@@ -125,7 +145,9 @@ export class NotificationsService {
       .select('id');
 
     if (error) {
-      this.logger.error(`Failed to mark all notifications as read for ${wallet}: ${error.message}`);
+      this.logger.error(
+        `Failed to mark all notifications as read for ${wallet}: ${error.message}`,
+      );
       throw new Error(error.message);
     }
 

--- a/test/unit/modules/notifications/notifications.service.spec.ts
+++ b/test/unit/modules/notifications/notifications.service.spec.ts
@@ -1,0 +1,384 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { NotificationsService } from '../../../../src/modules/notifications/notifications.service';
+
+type SupabaseResult<T> = {
+  data?: T;
+  error?: { message: string } | null;
+  count?: number | null;
+};
+
+function createQueryBuilder<T>(result: SupabaseResult<T>) {
+  const query: Record<string, jest.Mock> = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    range: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue(result),
+    then: jest.fn((resolve, reject) =>
+      Promise.resolve(result).then(resolve, reject),
+    ),
+  };
+
+  return query;
+}
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  const wallet = 'GUSER1234567890';
+  const otherWallet = 'GOTHER1234567890';
+  const now = '2026-05-27T10:00:00.000Z';
+
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn(),
+  };
+
+  const mockNotification = {
+    id: 'notification-1',
+    type: 'loan_reminder',
+    title: 'Payment Due Soon',
+    message: 'Your loan payment is due in 3 days.',
+    data: { loanId: 'loan-1', amount: 108 },
+    is_read: false,
+    created_at: '2026-05-26T10:00:00.000Z',
+    read_at: null,
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers().setSystemTime(new Date(now));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  function mockClientWithQueries(...queries: Record<string, jest.Mock>[]) {
+    const client = {
+      from: jest.fn(() => {
+        const query = queries.shift();
+        if (!query) {
+          throw new Error('Unexpected Supabase query');
+        }
+        return query;
+      }),
+    };
+
+    mockSupabaseService.getServiceRoleClient.mockReturnValue(client);
+    return client;
+  }
+
+  describe('getNotifications', () => {
+    function setupListQuery(
+      notifications: unknown[] = [mockNotification],
+      count = notifications.length,
+      unreadCount = 3,
+    ) {
+      const listQuery = createQueryBuilder({
+        data: notifications,
+        error: null,
+        count,
+      });
+      const unreadCountQuery = createQueryBuilder({
+        data: null,
+        error: null,
+        count: unreadCount,
+      });
+      const client = mockClientWithQueries(listQuery, unreadCountQuery);
+
+      return { client, listQuery, unreadCountQuery };
+    }
+
+    it('lists notifications for a user with default pagination and unread count', async () => {
+      const { client, listQuery, unreadCountQuery } = setupListQuery();
+
+      const result = await service.getNotifications(wallet, {});
+
+      expect(client.from).toHaveBeenCalledWith('notifications');
+      expect(listQuery.select).toHaveBeenCalledWith(
+        'id, type, title, message, data, is_read, created_at, read_at',
+        { count: 'exact' },
+      );
+      expect(listQuery.eq).toHaveBeenCalledWith('user_wallet', wallet);
+      expect(listQuery.order).toHaveBeenCalledWith('created_at', {
+        ascending: false,
+      });
+      expect(listQuery.range).toHaveBeenCalledWith(0, 19);
+      expect(unreadCountQuery.select).toHaveBeenCalledWith('id', {
+        count: 'exact',
+        head: true,
+      });
+      expect(unreadCountQuery.eq).toHaveBeenCalledWith('user_wallet', wallet);
+      expect(unreadCountQuery.eq).toHaveBeenCalledWith('is_read', false);
+      expect(result).toEqual({
+        data: [
+          {
+            id: 'notification-1',
+            type: 'loan_reminder',
+            title: 'Payment Due Soon',
+            message: 'Your loan payment is due in 3 days.',
+            data: { loanId: 'loan-1', amount: 108 },
+            isRead: false,
+            createdAt: '2026-05-26T10:00:00.000Z',
+            readAt: null,
+          },
+        ],
+        pagination: {
+          limit: 20,
+          offset: 0,
+          total: 1,
+        },
+        unreadCount: 3,
+      });
+    });
+
+    it('filters notifications by unread status', async () => {
+      const { listQuery } = setupListQuery();
+
+      await service.getNotifications(wallet, { unread: true });
+
+      expect(listQuery.eq).toHaveBeenCalledWith('is_read', false);
+    });
+
+    it('does not apply an unread filter when unread is false', async () => {
+      const { listQuery } = setupListQuery();
+
+      await service.getNotifications(wallet, { unread: false });
+
+      expect(listQuery.eq).not.toHaveBeenCalledWith('is_read', false);
+    });
+
+    it('filters notifications by type', async () => {
+      const { listQuery } = setupListQuery();
+
+      await service.getNotifications(wallet, { type: 'loan_reminder' });
+
+      expect(listQuery.eq).toHaveBeenCalledWith('type', 'loan_reminder');
+    });
+
+    it('applies limit and offset pagination', async () => {
+      const { listQuery } = setupListQuery([mockNotification], 25, 4);
+
+      const result = await service.getNotifications(wallet, {
+        limit: 10,
+        offset: 20,
+      });
+
+      expect(listQuery.range).toHaveBeenCalledWith(20, 29);
+      expect(result.pagination).toEqual({
+        limit: 10,
+        offset: 20,
+        total: 25,
+      });
+    });
+
+    it('returns empty data and zero totals when no notifications exist', async () => {
+      const { listQuery } = setupListQuery([], 0, 0);
+
+      const result = await service.getNotifications(wallet, {});
+
+      expect(listQuery.range).toHaveBeenCalledWith(0, 19);
+      expect(result).toEqual({
+        data: [],
+        pagination: {
+          limit: 20,
+          offset: 0,
+          total: 0,
+        },
+        unreadCount: 0,
+      });
+    });
+
+    it('uses an empty object when notification data is null', async () => {
+      setupListQuery([
+        {
+          ...mockNotification,
+          data: null,
+          read_at: '2026-05-27T09:00:00.000Z',
+        },
+      ]);
+
+      const result = await service.getNotifications(wallet, {});
+
+      expect(result.data[0]).toMatchObject({
+        data: {},
+        readAt: '2026-05-27T09:00:00.000Z',
+      });
+    });
+
+    it('throws when the notification list query fails', async () => {
+      const listQuery = createQueryBuilder({
+        data: null,
+        error: { message: 'list failed' },
+        count: null,
+      });
+      const unreadCountQuery = createQueryBuilder({
+        data: null,
+        error: null,
+        count: 0,
+      });
+      mockClientWithQueries(listQuery, unreadCountQuery);
+
+      await expect(service.getNotifications(wallet, {})).rejects.toThrow(
+        'list failed',
+      );
+    });
+
+    it('throws when unread count calculation fails', async () => {
+      const listQuery = createQueryBuilder({
+        data: [mockNotification],
+        error: null,
+        count: 1,
+      });
+      const unreadCountQuery = createQueryBuilder({
+        data: null,
+        error: { message: 'count failed' },
+        count: null,
+      });
+      mockClientWithQueries(listQuery, unreadCountQuery);
+
+      await expect(service.getNotifications(wallet, {})).rejects.toThrow(
+        'count failed',
+      );
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('marks an owned unread notification as read', async () => {
+      const fetchQuery = createQueryBuilder({
+        data: { id: 'notification-1', user_wallet: wallet, is_read: false },
+        error: null,
+      });
+      const updateQuery = createQueryBuilder({ error: null });
+      mockClientWithQueries(fetchQuery, updateQuery);
+
+      const result = await service.markAsRead(wallet, 'notification-1');
+
+      expect(fetchQuery.select).toHaveBeenCalledWith(
+        'id, user_wallet, is_read',
+      );
+      expect(fetchQuery.eq).toHaveBeenCalledWith('id', 'notification-1');
+      expect(updateQuery.update).toHaveBeenCalledWith({
+        is_read: true,
+        read_at: now,
+        updated_at: now,
+      });
+      expect(updateQuery.eq).toHaveBeenCalledWith('id', 'notification-1');
+      expect(result).toEqual({ success: true, updatedCount: 1 });
+    });
+
+    it('returns zero updates when an owned notification is already read', async () => {
+      const fetchQuery = createQueryBuilder({
+        data: { id: 'notification-1', user_wallet: wallet, is_read: true },
+        error: null,
+      });
+      mockClientWithQueries(fetchQuery);
+
+      const result = await service.markAsRead(wallet, 'notification-1');
+
+      expect(result).toEqual({ success: true, updatedCount: 0 });
+    });
+
+    it('validates notification ownership before updating', async () => {
+      const fetchQuery = createQueryBuilder({
+        data: {
+          id: 'notification-1',
+          user_wallet: otherWallet,
+          is_read: false,
+        },
+        error: null,
+      });
+      mockClientWithQueries(fetchQuery);
+
+      await expect(
+        service.markAsRead(wallet, 'notification-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFoundException for non-existent notification IDs', async () => {
+      const fetchQuery = createQueryBuilder({
+        data: null,
+        error: { message: 'not found' },
+      });
+      mockClientWithQueries(fetchQuery);
+
+      await expect(
+        service.markAsRead(wallet, 'missing-notification'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws when updating an unread notification fails', async () => {
+      const fetchQuery = createQueryBuilder({
+        data: { id: 'notification-1', user_wallet: wallet, is_read: false },
+        error: null,
+      });
+      const updateQuery = createQueryBuilder({
+        error: { message: 'update failed' },
+      });
+      mockClientWithQueries(fetchQuery, updateQuery);
+
+      await expect(
+        service.markAsRead(wallet, 'notification-1'),
+      ).rejects.toThrow('update failed');
+    });
+  });
+
+  describe('markAllAsRead', () => {
+    it('marks all unread notifications for a user as read', async () => {
+      const updateQuery = createQueryBuilder({
+        data: [{ id: 'notification-1' }, { id: 'notification-2' }],
+        error: null,
+      });
+      mockClientWithQueries(updateQuery);
+
+      const result = await service.markAllAsRead(wallet);
+
+      expect(updateQuery.update).toHaveBeenCalledWith({
+        is_read: true,
+        read_at: now,
+        updated_at: now,
+      });
+      expect(updateQuery.eq).toHaveBeenCalledWith('user_wallet', wallet);
+      expect(updateQuery.eq).toHaveBeenCalledWith('is_read', false);
+      expect(updateQuery.select).toHaveBeenCalledWith('id');
+      expect(result).toEqual({ success: true, updatedCount: 2 });
+    });
+
+    it('returns zero when no unread notifications exist', async () => {
+      const updateQuery = createQueryBuilder({
+        data: [],
+        error: null,
+      });
+      mockClientWithQueries(updateQuery);
+
+      const result = await service.markAllAsRead(wallet);
+
+      expect(result).toEqual({ success: true, updatedCount: 0 });
+    });
+
+    it('throws when marking all notifications as read fails', async () => {
+      const updateQuery = createQueryBuilder({
+        data: null,
+        error: { message: 'bulk update failed' },
+      });
+      mockClientWithQueries(updateQuery);
+
+      await expect(service.markAllAsRead(wallet)).rejects.toThrow(
+        'bulk update failed',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #75

---

## 🔖 Title

Add NotificationsService unit tests

---

## 📝 Description

Adds comprehensive unit tests for `NotificationsService` covering notification listing, unread/type filtering, pagination, unread counts, marking notifications as read, ownership validation, missing notifications, empty lists, and database error handling.

This also adds the missing notification type filter support required by the requested tests.

---

## 🔄 Changes Made

- [x] Added notification type query validation and service filtering
- [x] Added mocked Supabase query coverage for notification listing and unread counts
- [x] Added mark-as-read and mark-all-as-read unit tests

---

## 📈 Testing

- [x] `.\node_modules\.bin\jest.cmd notifications.service.spec.ts --runInBand`
- [x] Service-specific coverage for `NotificationsService`: 100% statements, 100% lines, 100% functions, 85.18% branches
- [x] `.\node_modules\.bin\nest.cmd build`

### 📈 Test Output

```text
PASS test/unit/modules/notifications/notifications.service.spec.ts
  NotificationsService
    getNotifications
      √ lists notifications for a user with default pagination and unread count (17 ms)
      √ filters notifications by unread status (3 ms)
      √ does not apply an unread filter when unread is false (2 ms)
      √ filters notifications by type (2 ms)
      √ applies limit and offset pagination (3 ms)
      √ returns empty data and zero totals when no notifications exist (2 ms)
      √ uses an empty object when notification data is null (1 ms)
      √ throws when the notification list query fails (15 ms)
      √ throws when unread count calculation fails (3 ms)
    markAsRead
      √ marks an owned unread notification as read (3 ms)
      √ returns zero updates when an owned notification is already read (2 ms)
      √ validates notification ownership before updating (2 ms)
      √ throws NotFoundException for non-existent notification IDs (2 ms)
      √ throws when updating an unread notification fails (2 ms)
    markAllAsRead
      √ marks all unread notifications for a user as read (2 ms)
      √ returns zero when no unread notifications exist (2 ms)
      √ throws when marking all notifications as read fails (2 ms)

Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        3.519 s, estimated 5 s
Ran all test suites matching /notifications.service.spec.ts/i.
```

### Coverage Output

```text
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |    85.18 |     100 |     100 |
 notifications.service.ts |     100 |    85.18 |     100 |     100 | 68,84-86,154
--------------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

---

## 📸 Screenshots

N/A

---
