### PR TITLE
Add LoansService unit tests

### DIFF
--- a/test/unit/modules/loans/loans.service.spec.ts
+++ b/test/unit/modules/loans/loans.service.spec.ts
@@ -306,6 +306,18 @@ describe('LoansService', () => {
         InternalServerErrorException,
       );
     });
+
+    it('should handle missing error message on pending loan persistence failure', async () => {
+      mockReputation(75, 'silver', 8, 2000);
+      mockMerchantFound();
+      mockSupabaseFrom.insert.mockResolvedValue({
+        error: { message: null },
+      });
+
+      await expect(service.createLoan(validWallet, baseDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
   });
 
   describe('repayLoan', () => {
@@ -533,6 +545,39 @@ describe('LoansService', () => {
         InternalServerErrorException,
       );
     });
+
+    it('should calculate available credit for gold tier reputation (score >= 90)', async () => {
+      mockReputationContractClient.getScore.mockResolvedValue(95);
+      mockSupabaseFrom.eq
+        .mockImplementationOnce(() => mockSupabaseFrom)
+        .mockResolvedValueOnce({
+          data: [{ remaining_balance: 1000 }],
+          error: null,
+        });
+
+      const result = await service.getAvailableCredit(validWallet);
+
+      expect(result).toEqual({
+        reputationScore: 95,
+        reputationTier: 'gold',
+        maxCreditLimit: 5000,
+        creditUsed: 1000,
+        availableCredit: 4000,
+        activeLoans: 1,
+      });
+    });
+
+    it('should handle null/undefined remaining balances or empty loan list', async () => {
+      mockSupabaseFrom.eq
+        .mockImplementationOnce(() => mockSupabaseFrom)
+        .mockResolvedValueOnce({
+          data: [{ remaining_balance: null }],
+          error: null,
+        });
+
+      const result = await service.getAvailableCredit(validWallet);
+      expect(result.creditUsed).toBe(0);
+    });
   });
 
   describe('getMyLoans', () => {
@@ -664,6 +709,54 @@ describe('LoansService', () => {
           offset: 0,
         }),
       ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should use default limit (20) and offset (0) when not provided in query', async () => {
+      const result = await service.getMyLoans(validWallet, {});
+      expect(mockSupabaseFrom.range).toHaveBeenCalledWith(0, 19);
+    });
+
+    it('should handle merchants array and null loan payments', async () => {
+      mockSupabaseFrom.eq.mockImplementation((column: string, value: unknown) => {
+        if (column === 'status' && value === LoanListStatusFilter.ACTIVE) {
+          return Promise.resolve({
+            data: [
+              {
+                id: '11111111-2222-3333-4444-555555555555',
+                loan_id: 'chain-loan-1',
+                merchant_id: merchantId,
+                amount: 500,
+                loan_amount: 400,
+                guarantee: 100,
+                interest_rate: 8,
+                total_repayment: 410.67,
+                remaining_balance: 205.33,
+                term: 4,
+                status: 'active',
+                next_payment_due: null,
+                created_at: '2026-03-13T00:00:00.000Z',
+                completed_at: null,
+                defaulted_at: null,
+                merchants: [
+                  {
+                    id: merchantId,
+                    name: 'TechStore',
+                    logo: 'https://cdn.trustup.app/techstore.png',
+                  },
+                ],
+                loan_payments: null,
+              },
+            ],
+            error: null,
+            count: 1,
+          });
+        }
+        return mockSupabaseFrom;
+      });
+
+      const result = await service.getMyLoans(validWallet, { status: LoanListStatusFilter.ACTIVE });
+      expect(result.data[0].merchant.name).toBe('TechStore');
+      expect(result.data[0].nextPayment.dueDate).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Related Issue

Closes #71

---

## 🔖 Title

Unit Tests for LoanService

---

## 📝 Description

Added comprehensive unit tests for the `LoansService` in order to test all core functionality, blockchain interactions, database orchestrations, and edge cases. By implementing new test cases, we have successfully achieved 100% line coverage, 100% statement coverage, 100% function coverage, and 81.25% branch coverage for `loans.service.ts`.

---

## 🔄 Changes Made

- **`test/unit/modules/loans/loans.service.spec.ts`**:
  - Added test case for **Gold Tier Credit Limit Mapping**: verifies reputation scores `>= 90` map correctly to the Gold tier inside `getAvailableCredit`.
  - Added test case for **Null/Undefined Fallback Logic**: verifies calculation logic inside `getAvailableCredit` handles missing on-chain or off-chain loan parameters gracefully.
  - Added test case for **DB Persistence Failure Fallback**: tests that missing error messages on Supabase insert failures fallback to default messages during loan creation.
  - Added test case for **Default Query Limit/Offset**: checks that default limits (20) and offsets (0) are applied when query payload is omitted in `getMyLoans`.
  - Added test case for **Merchant array & Null payment normalization**: tests logic inside `getMyLoans` that normalizes array data and handles empty payments.

---

## 📈 Testing

### 📈 Test Output

```bash
PASS test/unit/modules/loans/loans.service.spec.ts
  LoansService
    √ should be defined (9 ms)
    calculateLoanQuote
      √ should calculate a quote for a gold tier user (3 ms)
      √ should calculate a quote for a silver tier user (2 ms)
      √ should calculate a quote for a bronze tier user (1 ms)
      √ should calculate a quote for a poor tier user (1 ms)
      √ should reject amount exceeding max credit (17 ms)
      √ should throw NotFoundException when merchant does not exist (2 ms)
      √ should throw BadRequestException when merchant is inactive (1 ms)
      √ should set guarantee to 20% and loan to 80% of amount (1 ms)
      √ should handle fractional amounts correctly (1 ms)
    createLoan
      √ should create a pending loan with XDR and terms (2 ms)
      √ should reject loan creation when reputation is below minimum threshold (1 ms)
      √ should throw InternalServerErrorException when XDR construction fails (2 ms)
      √ should throw InternalServerErrorException when pending loan persistence fails (1 ms)
      √ should handle missing error message on pending loan persistence failure (1 ms)
    repayLoan
      √ should return unsigned XDR and payment preview (1 ms)
      √ should throw NotFoundException when loan does not exist (1 ms)
      √ should throw NotFoundException when loan belongs to another user (1 ms)
      √ should throw BadRequestException when loan is not active
      √ should throw BadRequestException when payment exceeds balance
      √ should mark payment as completing the loan when balance reaches zero
    generateSchedule
      √ should generate correct number of payments (1 ms)
      √ should have sequential payment numbers (1 ms)
      √ should sum to totalRepayment exactly (1 ms)
      √ should have due dates 30 days apart (monthly) (2 ms)
      √ should handle single payment term
      √ should handle rounding remainder in last payment
      √ should return valid ISO date strings (1 ms)
    getAvailableCredit
      √ should calculate available credit from on-chain score and active loans (1 ms)
      √ should treat missing on-chain score as zero reputation
      √ should never return negative available credit (1 ms)
      √ should throw ServiceUnavailableException when blockchain lookup fails (2 ms)
      √ should throw InternalServerErrorException when active loans query fails
      √ should calculate available credit for gold tier reputation (score >= 90)
      √ should handle null/undefined remaining balances or empty loan list (1 ms)
    getMyLoans
      √ should return paginated loans with derived totals and next payment details (2 ms)
      √ should return an empty paginated result when the user has no indexed loans (6 ms)
      √ should throw InternalServerErrorException when the loans query fails (1 ms)
      √ should use default limit (20) and offset (0) when not provided in query
      √ should handle merchants array and null loan payments

Test Suites: 1 passed, 1 total
Tests:       40 passed, 40 total
Snapshots:   0 total
Time:        5.234 s
```

### Coverage Output

```bash
------------------|---------|----------|---------|---------|-------------------------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                   
------------------|---------|----------|---------|---------|-------------------------------------
All files         |     100 |    81.25 |     100 |     100 |                                     
 loans.service.ts |     100 |    81.25 |     100 |     100 | 139,278-282,317-327,458-462,492-494 
------------------|---------|----------|---------|---------|-------------------------------------
```

---

## 📸 Screenshots

N/A (Backend API unit tests only)

---
