### PR TITLE
Fix GET /reputation/me — unreachable route and missing auth guard

### DIFF
--- a/src/modules/reputation/reputation.controller.ts
+++ b/src/modules/reputation/reputation.controller.ts
@@ -2,17 +2,34 @@ import {
     Controller,
     Get,
     Param,
-    Request,
-    UnauthorizedException,
+    UseGuards,
     BadRequestException,
 } from '@nestjs/common';
 import { ReputationService } from './reputation.service';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
 @ApiTags('Reputation')
 @Controller('reputation')
 export class ReputationController {
     constructor(private readonly reputationService: ReputationService) { }
+
+    @Get('me')
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get reputation score for the authenticated user' })
+    @ApiResponse({ status: 200, description: 'Reputation data retrieved successfully' })
+    @ApiResponse({ status: 401, description: 'Unauthorized — missing or invalid JWT' })
+    async getMyScore(@CurrentUser() user: { wallet: string }) {
+        const data = await this.reputationService.getReputationScore(user.wallet);
+
+        return {
+            success: true,
+            data,
+            message: 'Your reputation data retrieved successfully',
+        };
+    }
 
     @Get(':wallet')
     @ApiOperation({ summary: 'Get reputation score for a specific wallet' })
@@ -36,27 +53,6 @@ export class ReputationController {
             success: true,
             data,
             message: 'Reputation data retrieved successfully',
-        };
-    }
-
-    @Get('me')
-    @ApiOperation({ summary: 'Get reputation score for the authenticated user' })
-    async getMyScore(@Request() req: any) {
-        const wallet = req.user?.wallet;
-
-        if (!wallet) {
-            throw new UnauthorizedException({
-                success: false,
-                message: 'No authenticated wallet found in request session',
-            });
-        }
-
-        const data = await this.reputationService.getReputationScore(wallet);
-
-        return {
-            success: true,
-            data,
-            message: 'Your reputation data retrieved successfully',
         };
     }
 }

--- a/src/modules/reputation/reputation.module.ts
+++ b/src/modules/reputation/reputation.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { ReputationService } from './reputation.service';
 import { ReputationController } from './reputation.controller';
 import * as redisStore from 'cache-manager-redis-store';
 import { SupabaseService } from '../../database/supabase.client';
+import { getJwtConfig } from '../../config/jwt.config';
 
 @Module({
     imports: [
@@ -15,6 +18,12 @@ import { SupabaseService } from '../../database/supabase.client';
                 store: redisStore,
                 url: configService.get<string>('REDIS_URL', 'redis://localhost:6379'),
             }),
+        }),
+        PassportModule.register({ defaultStrategy: 'jwt' }),
+        JwtModule.registerAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: getJwtConfig,
         }),
     ],
     providers: [ReputationService, SupabaseService],

--- a/test/e2e/modules/reputation/reputation.e2e-spec.ts
+++ b/test/e2e/modules/reputation/reputation.e2e-spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, UnauthorizedException } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { ReputationModule } from '../../../../src/modules/reputation/reputation.module';
 import { ReputationContractClient } from '../../../../src/blockchain/contracts/reputation-contract.client';
 import { SorobanService } from '../../../../src/blockchain/soroban/soroban.service';
+import { JwtAuthGuard } from '../../../../src/common/guards/jwt-auth.guard';
 
 describe('ReputationController (e2e)', () => {
   let app: NestFastifyApplication;
@@ -21,6 +22,20 @@ describe('ReputationController (e2e)', () => {
     getNetworkPassphrase: jest.fn().mockReturnValue('Test SDF Network ; September 2015'),
   };
 
+  // Mock guard that simulates JwtAuthGuard behavior: throws UnauthorizedException
+  // when no Bearer token is present, otherwise sets req.user = { wallet }.
+  const mockJwtAuthGuard = {
+    canActivate: jest.fn((context) => {
+      const req = context.switchToHttp().getRequest();
+      const authHeader = req.headers['authorization'];
+      if (!authHeader?.startsWith('Bearer ')) {
+        throw new UnauthorizedException('No token provided');
+      }
+      req.user = { wallet: validWallet };
+      return true;
+    }),
+  };
+
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
@@ -32,6 +47,8 @@ describe('ReputationController (e2e)', () => {
       .useValue(mockReputationContract)
       .overrideProvider(SorobanService)
       .useValue(mockSorobanService)
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
       .compile();
 
     app = moduleFixture.createNestApplication<NestFastifyApplication>(
@@ -52,6 +69,19 @@ describe('ReputationController (e2e)', () => {
 
   afterAll(async () => {
     if (app) await app.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockJwtAuthGuard.canActivate.mockImplementation((context) => {
+      const req = context.switchToHttp().getRequest();
+      const authHeader = req.headers['authorization'];
+      if (!authHeader?.startsWith('Bearer ')) {
+        throw new UnauthorizedException('No token provided');
+      }
+      req.user = { wallet: validWallet };
+      return true;
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -133,14 +163,50 @@ describe('ReputationController (e2e)', () => {
   // GET /reputation/me
   // ---------------------------------------------------------------------------
   describe('GET /reputation/me', () => {
-    it('should return 401 since auth guard is not yet implemented', async () => {
+    it('should return 200 with reputation data when a valid token is provided', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/reputation/me',
+        headers: { authorization: 'Bearer valid.jwt.token' },
+      });
+
+      expect(res.statusCode).toBe(200);
+
+      const body = JSON.parse(res.payload);
+      expect(body.success).toBe(true);
+      expect(body.message).toBe('Your reputation data retrieved successfully');
+      expect(body.data).toHaveProperty('wallet', validWallet);
+    }, 10000);
+
+    it('should return 401 when no token is provided', async () => {
       const res = await app.inject({
         method: 'GET',
         url: '/reputation/me',
       });
 
-      // Returns 401 because auth guard (API-03) is not wired yet
       expect(res.statusCode).toBe(401);
     });
+
+    it('should return 401 when Authorization header is malformed', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/reputation/me',
+        headers: { authorization: 'InvalidScheme token123' },
+      });
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('should not be captured by the :wallet route (route precedence)', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/reputation/me',
+        headers: { authorization: 'Bearer valid.jwt.token' },
+      });
+
+      // If ':wallet' captured 'me', the Stellar address regex would reject it
+      // with a 400 (Invalid Stellar wallet address format) instead of 200/401.
+      expect(res.statusCode).not.toBe(400);
+    }, 10000);
   });
 });

--- a/test/unit/modules/reputation/reputation.controller.spec.ts
+++ b/test/unit/modules/reputation/reputation.controller.spec.ts
@@ -1,7 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { ReputationController } from '../../../../src/modules/reputation/reputation.controller';
 import { ReputationService } from '../../../../src/modules/reputation/reputation.service';
+import { JwtAuthGuard } from '../../../../src/common/guards/jwt-auth.guard';
 
 describe('ReputationController', () => {
   let controller: ReputationController;
@@ -12,6 +13,7 @@ describe('ReputationController', () => {
   };
 
   const validWallet = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+  const mockCurrentUser = { wallet: validWallet };
 
   const mockReputationResponse = {
     wallet: validWallet,
@@ -31,7 +33,10 @@ describe('ReputationController', () => {
           useValue: mockReputationService,
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
 
     controller = module.get<ReputationController>(ReputationController);
     reputationService = module.get<ReputationService>(ReputationService);
@@ -99,11 +104,30 @@ describe('ReputationController', () => {
   // GET /reputation/me
   // ---------------------------------------------------------------------------
   describe('getMyScore', () => {
-    it('should throw UnauthorizedException since auth guard is not yet wired', async () => {
-      await expect(controller.getMyScore({})).rejects.toThrow(
-        UnauthorizedException,
+    it('should return reputation data for the authenticated wallet', async () => {
+      mockReputationService.getReputationScore.mockResolvedValue(mockReputationResponse);
+
+      const result = await controller.getMyScore(mockCurrentUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: mockReputationResponse,
+        message: 'Your reputation data retrieved successfully',
+      });
+      expect(reputationService.getReputationScore).toHaveBeenCalledWith(validWallet);
+      expect(reputationService.getReputationScore).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate service errors to the caller', async () => {
+      mockReputationService.getReputationScore.mockRejectedValue(
+        new Error('Contract read failed'),
+      );
+
+      await expect(controller.getMyScore(mockCurrentUser)).rejects.toThrow(
+        'Contract read failed',
       );
     });
   });
+
 });
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #115

---

## 🔖 Title
Fix `GET /reputation/me` — unreachable route and missing auth guard

---

## 📝 Description
`GET /reputation/me` was permanently unreachable and would not have worked even if reached, due to two separate bugs:

1. **Route ordering** — `@Get(':wallet')` was declared before `@Get('me')`, so Fastify matched `/reputation/me` against the `:wallet` handler first. The wallet regex rejects `"me"`, so the endpoint always 400'd.
2. **Missing auth guard** — the handler read `req.user?.wallet` directly with no `@UseGuards(JwtAuthGuard)`, so `req.user` was always `undefined` and the endpoint always threw `UnauthorizedException`.

---

## 🔄 Changes Made
- [x] Moved `@Get('me')` above `@Get(':wallet')` in `reputation.controller.ts`
- [x] Added `@UseGuards(JwtAuthGuard)` + `@ApiBearerAuth()` to `GET /reputation/me`
- [x] Replaced raw `@Request() req` with `@CurrentUser() user`, matching the `GET /users/me` pattern
- [x] Imported `PassportModule` and `JwtModule` in `reputation.module.ts`
- [x] Updated `reputation.controller.spec.ts`: authenticated call returns score, guard-mocked, errors propagate
- [x] Updated `reputation.e2e-spec.ts`: valid token → 200, no token → 401, malformed header → 401, route precedence (`/me` not swallowed by `:wallet`)

---

## 📸 Screenshots (if applicable)
N/A — backend-only change, no UI impact.

---

## ✅ Test Evidence

**Unit tests (`npx jest`)** — full suite, no regressions:
```
Test Suites: 18 passed, 18 total
Tests:       228 passed, 228 total
Time:        13.368 s
```

**Reputation unit tests (`npx jest reputation`):**
```
PASS test/unit/modules/reputation/reputation.controller.spec.ts
PASS test/unit/modules/reputation/reputation.service.spec.ts
Test Suites: 2 passed, 2 total
Tests:       19 passed, 19 total
```

**Reputation e2e tests (`npx jest --config ./test/jest-e2e.json reputation`):**
```
GET /reputation/:wallet
  × should return 200 with reputation data for a valid wallet
  × should return 200 with default score when wallet has no on-chain data
  √ should return 400 for an invalid wallet address
  √ should return 400 for a wallet that does not start with G
  × should return 500 when the blockchain RPC is unavailable
GET /reputation/me
  √ should return 200 with reputation data when a valid token is provided
  √ should return 401 when no token is provided
  √ should return 401 when Authorization header is malformed
  √ should not be captured by the :wallet route (route precedence)

Tests: 3 failed, 6 passed, 9 total
```
All 6 `/reputation/me` cases (the scope of this issue) pass. The 3 failures under `GET /reputation/:wallet` are **pre-existing on `main`** — the test file mocks `ReputationContractClient`/`SorobanService`, but `ReputationService.getReputationScore` actually derives the score from an internal deterministic hash and never calls those clients. Confirmed by running the same suite against `main` before this branch's changes — identical 3 failures. Out of scope for this issue; left untouched to avoid scope creep.

---

## 🗒️ Additional Notes
- `PassportModule`/`JwtModule` were added to `reputation.module.ts` per the issue checklist. Functionally, `AuthGuard('jwt')` already works without them (the `'jwt'` Passport strategy registers globally once `AuthModule` loads in `AppModule` — this is why `UsersModule` works without importing them), but they're included explicitly per the issue's acceptance criteria and for clarity/robustness.
- No changes made to lint config — `npm run lint` currently fails on `main` itself (`ESLint couldn't find a configuration file`), unrelated to this PR.