### PR TITLE
feat: add idempotency key support for liquidity and loans endpoints

### DIFF
--- a/src/common/decorators/idempotency-key.decorator.ts
+++ b/src/common/decorators/idempotency-key.decorator.ts
@@ -1,0 +1,25 @@
+import {
+  BadRequestException,
+  createParamDecorator,
+  ExecutionContext,
+} from "@nestjs/common";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const IdempotencyKey = createParamDecorator(
+  (_data: unknown, context: ExecutionContext): string | undefined => {
+    const key = context.switchToHttp().getRequest().headers["idempotency-key"];
+    if (key === undefined) return undefined;
+
+    const value = Array.isArray(key) ? key[0] : key;
+    if (typeof value !== "string" || !UUID_V4.test(value)) {
+      throw new BadRequestException({
+        code: "IDEMPOTENCY_KEY_INVALID",
+        message: "Idempotency-Key must be a UUID v4.",
+      });
+    }
+
+    return value;
+  },
+);

--- a/src/common/interceptors/idempotency.interceptor.ts
+++ b/src/common/interceptors/idempotency.interceptor.ts
@@ -1,0 +1,61 @@
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Cache } from "cache-manager";
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Observable, from, of } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
+
+const IDEMPOTENCY_TTL = 24 * 60 * 60;
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const key = request.headers["idempotency-key"];
+    const idempotencyKey = Array.isArray(key) ? key[0] : key;
+    const userId = request.user?.id ?? request.user?.wallet;
+
+    if (typeof idempotencyKey !== "string" || !userId) {
+      return next.handle();
+    }
+
+    const endpoint =
+      request.routeOptions?.url ??
+      request.route?.path ??
+      request.routerPath ??
+      request.url.split("?")[0];
+    const cacheKey = `idempotency:${userId}:${endpoint}:${idempotencyKey}`;
+
+    return from(this.cacheManager.get(cacheKey)).pipe(
+      switchMap((cached) => {
+        if (cached === undefined || cached === null) {
+          return next
+            .handle()
+            .pipe(
+              switchMap((response) =>
+                from(
+                  this.cacheManager.set(cacheKey, response, IDEMPOTENCY_TTL),
+                ).pipe(map(() => response)),
+              ),
+            );
+        }
+
+        const response = http.getResponse();
+        if (typeof response.header === "function") {
+          response.header("X-Idempotent-Replayed", "true");
+        } else {
+          response.setHeader("X-Idempotent-Replayed", "true");
+        }
+        return of(cached);
+      }),
+    );
+  }
+}

--- a/src/database/repositories/loans.repository.ts
+++ b/src/database/repositories/loans.repository.ts
@@ -35,6 +35,7 @@ export interface CreateLoanRecord {
   term: number;
   status: "pending";
   next_payment_due: string | null;
+  xdr_hash: string;
 }
 
 export interface LoanStatusRecord {
@@ -116,6 +117,23 @@ export class LoansRepository {
     return (data ?? []) as Pick<LoanRecord, "remaining_balance">[];
   }
 
+  async hasPendingWithXdrHash(
+    wallet: string,
+    xdrHash: string,
+  ): Promise<boolean> {
+    const { data, error } = await this.supabaseService
+      .getServiceRoleClient()
+      .from("loans")
+      .select("id")
+      .eq("user_wallet", wallet)
+      .eq("xdr_hash", xdrHash)
+      .eq("status", "pending")
+      .maybeSingle();
+
+    this.throwOnError(error);
+    return data != null;
+  }
+
   async findStatusByLoanIdAndWallet(
     loanId: string,
     userWallet: string,
@@ -153,6 +171,9 @@ export class LoansRepository {
       .getServiceRoleClient()
       .from("loans")
       .insert(record);
+    if (error?.code === "23505") {
+      throw error;
+    }
     this.throwOnError(error);
   }
 
@@ -201,7 +222,7 @@ export class LoansRepository {
     this.throwOnError(error);
   }
 
-  private throwOnError(error: { message?: string } | null): void {
+  private throwOnError(error: { code?: string; message?: string } | null): void {
     if (error) {
       throw new InternalServerErrorException({
         code: "DATABASE_QUERY_ERROR",

--- a/src/modules/liquidity/liquidity.controller.ts
+++ b/src/modules/liquidity/liquidity.controller.ts
@@ -6,12 +6,14 @@ import {
   HttpStatus,
   Post,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
   ApiResponse,
   ApiTags,
+  ApiHeader,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { LiquidityService } from './liquidity.service';
@@ -23,6 +25,8 @@ import { LiquidityDepositRequestDto } from './dto/liquidity-deposit-request.dto'
 import { LiquidityDepositResponseDto } from './dto/liquidity-deposit-response.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { IdempotencyKey } from '../../common/decorators/idempotency-key.decorator';
+import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
 
 @ApiTags('liquidity')
 @Controller('liquidity')
@@ -88,7 +92,9 @@ export class LiquidityController {
   @Post('deposit')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(IdempotencyInterceptor)
   @ApiBearerAuth()
+  @ApiHeader({ name: 'Idempotency-Key', required: false, description: 'UUID v4 key used to safely replay this request for 24 hours.' })
   @ApiOperation({
     summary: 'Construct a liquidity pool deposit transaction',
     description:
@@ -105,6 +111,7 @@ export class LiquidityController {
   async depositLiquidity(
     @CurrentUser() user: { wallet: string },
     @Body() dto: LiquidityDepositRequestDto,
+    @IdempotencyKey() _idempotencyKey?: string,
   ): Promise<{ success: boolean; data: LiquidityDepositResponseDto; message: string }> {
     const data = await this.liquidityService.depositLiquidity(user.wallet, dto);
     return {
@@ -117,7 +124,9 @@ export class LiquidityController {
   @Post('withdraw')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(IdempotencyInterceptor)
   @ApiBearerAuth()
+  @ApiHeader({ name: 'Idempotency-Key', required: false, description: 'UUID v4 key used to safely replay this request for 24 hours.' })
   @ApiOperation({
     summary: 'Construct a liquidity withdrawal transaction',
     description:
@@ -135,6 +144,7 @@ export class LiquidityController {
   async withdrawLiquidity(
     @CurrentUser() user: { wallet: string },
     @Body() dto: LiquidityWithdrawRequestDto,
+    @IdempotencyKey() _idempotencyKey?: string,
   ): Promise<{ success: boolean; data: LiquidityWithdrawResponseDto; message: string }> {
     const data = await this.liquidityService.withdrawLiquidity(user.wallet, dto);
     return {

--- a/src/modules/liquidity/liquidity.module.ts
+++ b/src/modules/liquidity/liquidity.module.ts
@@ -9,6 +9,7 @@ import { SupabaseService } from '../../database/supabase.client';
 import { LiquidityRepository } from '../../database/repositories/liquidity.repository';
 import { SorobanService } from '../../blockchain/soroban/soroban.service';
 import { LiquidityContractClient } from '../../blockchain/contracts/liquidity-contract.client';
+import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { LiquidityContractClient } from '../../blockchain/contracts/liquidity-co
     SupabaseService,
     SorobanService,
     LiquidityContractClient,
+    IdempotencyInterceptor,
   ],
   exports: [LiquidityService],
 })

--- a/src/modules/loans/loans.controller.ts
+++ b/src/modules/loans/loans.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -17,6 +18,7 @@ import {
   ApiBearerAuth,
   ApiParam,
   ApiQuery,
+  ApiHeader,
 } from '@nestjs/swagger';
 import { LoansService } from './loans.service';
 import { LoanQuoteRequestDto } from './dto/loan-quote-request.dto';
@@ -30,6 +32,8 @@ import { LoanListQueryDto, LoanListStatusFilter } from './dto/loan-list-query.dt
 import { LoanListResponseDto } from './dto/loan-list-response.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { IdempotencyKey } from '../../common/decorators/idempotency-key.decorator';
+import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
 
 @ApiTags('loans')
 @Controller('loans')
@@ -125,7 +129,9 @@ export class LoansController {
   @Post('create')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(IdempotencyInterceptor)
   @ApiBearerAuth()
+  @ApiHeader({ name: 'Idempotency-Key', required: false, description: 'UUID v4 key used to safely replay this request for 24 hours.' })
   @ApiOperation({
     summary: 'Create BNPL loan',
     description:
@@ -146,6 +152,7 @@ export class LoansController {
   async createLoan(
     @CurrentUser() user: { wallet: string },
     @Body() dto: CreateLoanRequestDto,
+    @IdempotencyKey() _idempotencyKey?: string,
   ) {
     const data = await this.loansService.createLoan(user.wallet, dto);
     return { success: true, data, message: 'Pending loan created successfully' };
@@ -154,7 +161,9 @@ export class LoansController {
   @Post(':loanId/pay')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(IdempotencyInterceptor)
   @ApiBearerAuth()
+  @ApiHeader({ name: 'Idempotency-Key', required: false, description: 'UUID v4 key used to safely replay this request for 24 hours.' })
   @ApiParam({
     name: 'loanId',
     description: 'UUID of the loan to repay',
@@ -181,6 +190,7 @@ export class LoansController {
     @CurrentUser() user: { wallet: string },
     @Param('loanId', ParseUUIDPipe) loanId: string,
     @Body() dto: LoanPaymentRequestDto,
+    @IdempotencyKey() _idempotencyKey?: string,
   ) {
     const data = await this.loansService.repayLoan(user.wallet, loanId, dto);
     return { success: true, data, message: 'Repayment transaction constructed successfully' };

--- a/src/modules/loans/loans.module.ts
+++ b/src/modules/loans/loans.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { CacheModule } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoansController } from './loans.controller';
 import { LoansService } from './loans.service';
 import { AuthModule } from '../auth/auth.module';
@@ -10,9 +11,20 @@ import { MerchantsRepository } from '../../database/repositories/merchants.repos
 import { SorobanService } from '../../blockchain/soroban/soroban.service';
 import { CreditLineContractClient } from '../../blockchain/contracts/credit-line-contract.client';
 import { ReputationContractClient } from '../../blockchain/contracts/reputation-contract.client';
+import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
+import { getRedisConfig } from '../../config/redis.config';
 
 @Module({
-  imports: [ConfigModule, AuthModule, ReputationModule],
+  imports: [
+    ConfigModule,
+    AuthModule,
+    ReputationModule,
+    CacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: getRedisConfig,
+    }),
+  ],
   controllers: [LoansController],
   providers: [
     LoansService,
@@ -22,6 +34,7 @@ import { ReputationContractClient } from '../../blockchain/contracts/reputation-
     SorobanService,
     CreditLineContractClient,
     ReputationContractClient,
+    IdempotencyInterceptor,
   ],
   exports: [LoansService],
 })

--- a/src/modules/loans/loans.service.ts
+++ b/src/modules/loans/loans.service.ts
@@ -1,11 +1,13 @@
 import {
   Injectable,
   BadRequestException,
+  ConflictException,
   NotFoundException,
   Logger,
   InternalServerErrorException,
   ServiceUnavailableException,
 } from "@nestjs/common";
+import { createHash } from "crypto";
 import { ReputationService } from "../reputation/reputation.service";
 import {
   LoansRepository,
@@ -132,6 +134,14 @@ export class LoansService {
       });
     }
 
+    const xdrHash = createHash("sha256").update(xdr).digest("hex");
+    if (await this.hasPendingLoanWithXdrHash(wallet, xdrHash)) {
+      throw new ConflictException({
+        code: "LOAN_DUPLICATE_PENDING",
+        message: "An identical pending loan already exists.",
+      });
+    }
+
     try {
       await this.persistPendingLoan({
         loan_id: loanId,
@@ -146,8 +156,15 @@ export class LoansService {
         term: terms.term,
         status: "pending",
         next_payment_due: terms.schedule[0]?.dueDate ?? null,
+        xdr_hash: xdrHash,
       });
     } catch (error) {
+      if (error?.code === "23505") {
+        throw new ConflictException({
+          code: "LOAN_DUPLICATE_PENDING",
+          message: "An identical pending loan already exists.",
+        });
+      }
       this.logger.error(
         `Failed to persist pending loan ${loanId}: ${error.message}`,
       );
@@ -384,6 +401,20 @@ export class LoansService {
 
   private async persistPendingLoan(record: CreateLoanRecord): Promise<void> {
     await this.loansRepository.createLoan(record);
+  }
+
+  private async hasPendingLoanWithXdrHash(
+    wallet: string,
+    xdrHash: string,
+  ): Promise<boolean> {
+    try {
+      return await this.loansRepository.hasPendingWithXdrHash(wallet, xdrHash);
+    } catch {
+      throw new InternalServerErrorException({
+        code: "PENDING_LOAN_QUERY_FAILED",
+        message: "Failed to check for a duplicate pending loan.",
+      });
+    }
   }
 
   generateSchedule(totalRepayment: number, term: number): SchedulePaymentDto[] {

--- a/supabase/migrations/20260719000000_add_loans_xdr_hash.sql
+++ b/supabase/migrations/20260719000000_add_loans_xdr_hash.sql
@@ -1,0 +1,5 @@
+alter table public.loans add column if not exists xdr_hash text;
+
+create unique index if not exists idx_loans_pending_user_xdr_hash
+  on public.loans (user_wallet, xdr_hash)
+  where status = 'pending' and xdr_hash is not null;

--- a/test/unit/common/interceptors/idempotency.interceptor.spec.ts
+++ b/test/unit/common/interceptors/idempotency.interceptor.spec.ts
@@ -1,0 +1,94 @@
+import { CallHandler, ExecutionContext } from "@nestjs/common";
+import { lastValueFrom, of, throwError } from "rxjs";
+import { IdempotencyInterceptor } from "../../../../src/common/interceptors/idempotency.interceptor";
+
+describe("IdempotencyInterceptor", () => {
+  const cacheManager = { get: jest.fn(), set: jest.fn() };
+  const response = { header: jest.fn() };
+  const user = {
+    wallet: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+  };
+  const key = "550e8400-e29b-41d4-a716-446655440000";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function context(idempotencyKey = key): ExecutionContext {
+    const request = {
+      headers: { "idempotency-key": idempotencyKey },
+      user,
+      method: "POST",
+      routeOptions: { url: "/loans/create" },
+      url: "/loans/create",
+    };
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it("executes and caches the first request", async () => {
+    const interceptor = new IdempotencyInterceptor(cacheManager as any);
+    const next: CallHandler = { handle: jest.fn(() => of({ success: true })) };
+    cacheManager.get.mockResolvedValue(undefined);
+    cacheManager.set.mockResolvedValue(undefined);
+
+    await expect(
+      lastValueFrom(interceptor.intercept(context(), next)),
+    ).resolves.toEqual({ success: true });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      `idempotency:${user.wallet}:/loans/create:${key}`,
+      { success: true },
+      86400,
+    );
+  });
+
+  it("returns the cached response for the same key", async () => {
+    const interceptor = new IdempotencyInterceptor(cacheManager as any);
+    const next: CallHandler = { handle: jest.fn(() => of({ success: true })) };
+    const cached = { success: true, data: { loanId: "pending-loan" } };
+    cacheManager.get.mockResolvedValue(cached);
+
+    await expect(
+      lastValueFrom(interceptor.intercept(context(), next)),
+    ).resolves.toEqual(cached);
+    expect(next.handle).not.toHaveBeenCalled();
+    expect(response.header).toHaveBeenCalledWith(
+      "X-Idempotent-Replayed",
+      "true",
+    );
+  });
+
+  it("executes a request with a different key", async () => {
+    const interceptor = new IdempotencyInterceptor(cacheManager as any);
+    const next: CallHandler = { handle: jest.fn(() => of({ success: true })) };
+    const differentKey = "550e8400-e29b-41d4-a716-446655440001";
+    cacheManager.get.mockResolvedValue(undefined);
+    cacheManager.set.mockResolvedValue(undefined);
+
+    await lastValueFrom(interceptor.intercept(context(differentKey), next));
+
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(cacheManager.get).toHaveBeenCalledWith(
+      `idempotency:${user.wallet}:/loans/create:${differentKey}`,
+    );
+  });
+
+  it("does not cache handler errors", async () => {
+    const interceptor = new IdempotencyInterceptor(cacheManager as any);
+    const next: CallHandler = {
+      handle: jest.fn(() => throwError(() => new Error("failed"))),
+    };
+    cacheManager.get.mockResolvedValue(undefined);
+
+    await expect(
+      lastValueFrom(interceptor.intercept(context(), next)),
+    ).rejects.toThrow("failed");
+    expect(cacheManager.set).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/modules/liquidity/liquidity.controller.spec.ts
+++ b/test/unit/modules/liquidity/liquidity.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { LiquidityController } from "../../../../src/modules/liquidity/liquidity.controller";
 import { LiquidityService } from "../../../../src/modules/liquidity/liquidity.service";
+import { IdempotencyInterceptor } from '../../../../src/common/interceptors/idempotency.interceptor';
 
 describe("LiquidityController", () => {
   let controller: LiquidityController;
@@ -34,6 +36,8 @@ describe("LiquidityController", () => {
       controllers: [LiquidityController],
       providers: [
         { provide: LiquidityService, useValue: mockLiquidityService },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+        IdempotencyInterceptor,
       ],
     }).compile();
 

--- a/test/unit/modules/loans/loans.controller.spec.ts
+++ b/test/unit/modules/loans/loans.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { LoansController } from '../../../../src/modules/loans/loans.controller';
 import { LoansService } from '../../../../src/modules/loans/loans.service';
 import { CreateLoanResponseDto } from '../../../../src/modules/loans/dto/create-loan-response.dto';
 import { LoanListStatusFilter } from '../../../../src/modules/loans/dto/loan-list-query.dto';
+import { IdempotencyInterceptor } from '../../../../src/common/interceptors/idempotency.interceptor';
 
 describe('LoansController', () => {
   let controller: LoansController;
@@ -43,7 +45,11 @@ describe('LoansController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LoansController],
-      providers: [{ provide: LoansService, useValue: mockLoansService }],
+      providers: [
+        { provide: LoansService, useValue: mockLoansService },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+        IdempotencyInterceptor,
+      ],
     }).compile();
 
     controller = module.get<LoansController>(LoansController);

--- a/test/unit/modules/loans/loans.service.spec.ts
+++ b/test/unit/modules/loans/loans.service.spec.ts
@@ -77,8 +77,8 @@ describe('LoansService', () => {
     mockSupabaseFrom.order.mockReturnThis();
     mockSupabaseFrom.range.mockReturnThis();
     mockSupabaseFrom.update.mockReturnThis();
-    mockSupabaseFrom.maybeSingle.mockImplementation(() => mockSupabaseFrom.single());
     mockSupabaseFrom.insert.mockResolvedValue({ error: null });
+    mockSupabaseFrom.maybeSingle.mockResolvedValue({ data: null, error: null });
     mockCreditLineContractClient.buildCreateLoanTransaction.mockResolvedValue('AAAAAgAAAAC...');
     mockCreditLineContractClient.buildRepayLoanTx.mockResolvedValue('AAAAAgAAAAA...');
   });
@@ -281,6 +281,17 @@ describe('LoansService', () => {
       );
     });
 
+    it('should reject an existing pending loan with the same XDR hash', async () => {
+      mockReputation(75, 'silver', 8, 2000);
+      mockMerchantFound();
+      mockSupabaseFrom.maybeSingle.mockResolvedValue({ data: { id: 'existing-loan' }, error: null });
+
+      await expect(service.createLoan(validWallet, baseDto)).rejects.toMatchObject({
+        response: { code: 'LOAN_DUPLICATE_PENDING' },
+      });
+      expect(mockSupabaseFrom.insert).not.toHaveBeenCalled();
+    });
+
     it('should reject loan creation when reputation is below minimum threshold', async () => {
       mockReputation(59, 'poor', 12, 500);
       mockMerchantFound();
@@ -333,7 +344,7 @@ describe('LoansService', () => {
     const loanId = '11111111-2222-3333-4444-555555555555';
 
     function mockActiveLoan(overrides: Record<string, unknown> = {}) {
-      mockSupabaseFrom.single.mockResolvedValue({
+      mockSupabaseFrom.maybeSingle.mockResolvedValue({
         data: {
           id: loanId,
           loan_id: 'chain-loan-1',
@@ -368,7 +379,7 @@ describe('LoansService', () => {
     });
 
     it('should throw NotFoundException when loan does not exist', async () => {
-      mockSupabaseFrom.single.mockResolvedValue({
+      mockSupabaseFrom.maybeSingle.mockResolvedValue({
         data: null,
         error: null,
       });


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #119

---

## 🔖 Title

Implement idempotency key support for financial mutation endpoints

---

## 📝 Description

Adds optional idempotency protection to loan creation, loan payments, liquidity deposits, and liquidity withdrawals. Repeated requests with the same user, endpoint, and key return the original cached response instead of executing again.

---

## 🔄 Changes Made

- [x] Added UUID v4 `Idempotency-Key` validation and Redis-backed response replay for 24 hours
- [x] Applied idempotency support and Swagger header documentation to four financial mutation endpoints
- [x] Added pending-loan XDR hash duplicate protection with a database migration and unit tests

---


## 🗒️ Additional Notes

- `Idempotency-Key` is optional for backward compatibility.
- Replayed requests include `X-Idempotent-Replayed: true`.
- Verified with `npm run build` and relevant unit tests (57 passing).