### PR TITLE
Add unit tests for TransactionStatusCheckerProcessor and LoanPaymentReminderProcessor

### DIFF
--- a/src/jobs/loan-payment-reminder/loan-payment-reminder.processor.ts
+++ b/src/jobs/loan-payment-reminder/loan-payment-reminder.processor.ts
@@ -9,11 +9,18 @@ import {
   ReminderSummary,
   ReminderType,
 } from './interfaces/reminder.interfaces';
+import { daysUntilDueUtc, getReminderWindow, ReminderWindow } from './reminder-window.util';
 
 const REMINDER_TITLES: Record<ReminderType, string> = {
   payment_reminder_3d: 'Payment Due in 3 Days',
   payment_reminder_1d: 'Payment Due Tomorrow',
   payment_overdue: 'Loan Payment Overdue',
+};
+
+const REMINDER_WINDOW_TO_TYPE: Record<Exclude<ReminderWindow, null>, ReminderType> = {
+  'three-day': 'payment_reminder_3d',
+  'one-day': 'payment_reminder_1d',
+  overdue: 'payment_overdue',
 };
 
 function buildMessage(type: ReminderType, amount: string, dueDate: string): string {
@@ -182,32 +189,21 @@ export class LoanPaymentReminderProcessor extends WorkerHost {
    * consistently — the job always runs at 9 AM UTC, well away from midnight.
    */
   private identifyCandidates(loans: ActiveLoan[]): ReminderCandidate[] {
-    const nowUtc = new Date();
-    // Normalise to start of today in UTC for clean day arithmetic
-    const todayUtc = Date.UTC(nowUtc.getUTCFullYear(), nowUtc.getUTCMonth(), nowUtc.getUTCDate());
-
+    const now = new Date();
     const candidates: ReminderCandidate[] = [];
 
     for (const loan of loans) {
       if (!loan.next_payment_due) continue;
 
-      const dueUtc = new Date(loan.next_payment_due);
-      const dueDayUtc = Date.UTC(dueUtc.getUTCFullYear(), dueUtc.getUTCMonth(), dueUtc.getUTCDate());
-      const daysUntilDue = Math.round((dueDayUtc - todayUtc) / 86_400_000);
+      const dueDate = new Date(loan.next_payment_due);
+      const window = getReminderWindow(dueDate, now);
+      if (!window) continue;
 
-      let reminderType: ReminderType | null = null;
-
-      if (daysUntilDue === 3) {
-        reminderType = 'payment_reminder_3d';
-      } else if (daysUntilDue === 1) {
-        reminderType = 'payment_reminder_1d';
-      } else if (daysUntilDue < 0) {
-        reminderType = 'payment_overdue';
-      }
-
-      if (reminderType) {
-        candidates.push({ loan, reminderType, daysUntilDue });
-      }
+      candidates.push({
+        loan,
+        reminderType: REMINDER_WINDOW_TO_TYPE[window],
+        daysUntilDue: daysUntilDueUtc(dueDate, now),
+      });
     }
 
     return candidates;

--- a/src/jobs/loan-payment-reminder/reminder-window.util.ts
+++ b/src/jobs/loan-payment-reminder/reminder-window.util.ts
@@ -1,0 +1,31 @@
+export type ReminderWindow = 'three-day' | 'one-day' | 'overdue' | null;
+
+/**
+ * Whole-day difference (UTC calendar days) between `dueDate` and `now`.
+ * Positive when the due date is in the future, negative when overdue.
+ */
+export function daysUntilDueUtc(dueDate: Date, now: Date): number {
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const dueDayUtc = Date.UTC(dueDate.getUTCFullYear(), dueDate.getUTCMonth(), dueDate.getUTCDate());
+  return Math.round((dueDayUtc - todayUtc) / 86_400_000);
+}
+
+/**
+ * Classifies a due date into a reminder window based on UTC day difference.
+ * Pure function extracted from LoanPaymentReminderProcessor for isolated testing.
+ */
+export function getReminderWindow(dueDate: Date, now: Date): ReminderWindow {
+  const daysUntilDue = daysUntilDueUtc(dueDate, now);
+
+  if (daysUntilDue === 3) {
+    return 'three-day';
+  }
+  if (daysUntilDue === 1) {
+    return 'one-day';
+  }
+  if (daysUntilDue < 0) {
+    return 'overdue';
+  }
+
+  return null;
+}

--- a/src/jobs/transaction-status-checker/transaction-metadata.util.ts
+++ b/src/jobs/transaction-status-checker/transaction-metadata.util.ts
@@ -1,0 +1,70 @@
+import * as StellarSdk from 'stellar-sdk';
+
+export interface TransactionMetadata {
+  loanId?: string;
+  amount?: number;
+}
+
+/**
+ * Parses a signed Stellar XDR transaction and extracts `loanId`/`amount` from
+ * a `create_loan`/`repay_loan` `invokeHostFunction` operation, if present.
+ *
+ * Pure function: throws on malformed XDR instead of swallowing the error, so
+ * callers decide how to log/handle failures. Returns `null` when the XDR is
+ * well-formed but doesn't describe a recognised loan operation.
+ */
+export function parseTransactionMetadata(
+  xdr: string | null | undefined,
+  networkPassphrase: string,
+): TransactionMetadata | null {
+  if (!xdr) {
+    return null;
+  }
+
+  const transaction = StellarSdk.TransactionBuilder.fromXDR(xdr, networkPassphrase);
+  const innerTransaction =
+    transaction instanceof StellarSdk.FeeBumpTransaction
+      ? transaction.innerTransaction
+      : transaction;
+
+  const operation = innerTransaction.operations?.[0];
+  if (!operation || operation.type !== 'invokeHostFunction') {
+    return null;
+  }
+
+  const invocation = (operation.func as any)?._value?._attributes;
+  if (!invocation) {
+    return null;
+  }
+
+  const functionName = invocation.functionName?.toString?.();
+  const args = invocation.args as unknown[];
+  if (!Array.isArray(args) || !functionName) {
+    return null;
+  }
+
+  const nativeArgs = args.map((arg) => {
+    try {
+      return StellarSdk.scValToNative(arg as any);
+    } catch {
+      return undefined;
+    }
+  });
+
+  if (functionName === 'create_loan') {
+    return {
+      loanId: nativeArgs[0] as string,
+    };
+  }
+
+  if (functionName === 'repay_loan') {
+    const loanId = nativeArgs[1] as string;
+    const rawAmount = nativeArgs[2];
+    const amount = typeof rawAmount === 'bigint' ? Number(rawAmount) / 10_000_000 :
+      typeof rawAmount === 'number' ? rawAmount / 10_000_000 : undefined;
+
+    return { loanId, amount };
+  }
+
+  return null;
+}

--- a/src/jobs/transaction-status-checker/transaction-status-checker.processor.ts
+++ b/src/jobs/transaction-status-checker/transaction-status-checker.processor.ts
@@ -5,6 +5,7 @@ import { Job } from 'bullmq';
 import * as StellarSdk from 'stellar-sdk';
 import { SupabaseService } from '../../database/supabase.client';
 import { TransactionType } from '../../modules/transactions/dto/submit-transaction-request.dto';
+import { parseTransactionMetadata } from './transaction-metadata.util';
 
 interface PendingTransaction {
   id: string;
@@ -15,11 +16,6 @@ interface PendingTransaction {
   xdr?: string | null;
   submitted_at: string;
   updated_at: string;
-}
-
-interface TransactionMetadata {
-  loanId?: string;
-  amount?: number;
 }
 
 interface TransactionStatusResult {
@@ -328,7 +324,22 @@ export class TransactionStatusCheckerProcessor extends WorkerHost {
       return {};
     }
 
-    const metadata = this.parseTransactionMetadata(transaction.xdr);
+    let metadata: ReturnType<typeof parseTransactionMetadata>;
+    try {
+      metadata = parseTransactionMetadata(transaction.xdr, this.networkPassphrase);
+    } catch (error) {
+      this.logger.warn(
+        {
+          context: 'TransactionStatusCheckerProcessor',
+          action: 'parseTransactionMetadata',
+          error: error?.message,
+          transactionXdr: transaction.xdr?.slice(0, 64),
+        },
+        'Failed to parse transaction XDR for follow-up actions',
+      );
+      return {};
+    }
+
     if (!metadata?.loanId) {
       return {};
     }
@@ -461,72 +472,6 @@ export class TransactionStatusCheckerProcessor extends WorkerHost {
     }
 
     return { loanId, remainingBalance: updatedBalance, loanStatus: updatedStatus };
-  }
-
-  private parseTransactionMetadata(xdr?: string | null): TransactionMetadata | null {
-    if (!xdr) {
-      return null;
-    }
-
-    try {
-      const transaction = StellarSdk.TransactionBuilder.fromXDR(xdr, this.networkPassphrase);
-      const innerTransaction =
-        transaction instanceof StellarSdk.FeeBumpTransaction
-          ? transaction.innerTransaction
-          : transaction;
-
-      const operation = innerTransaction.operations?.[0];
-      if (!operation || operation.type !== 'invokeHostFunction') {
-        return null;
-      }
-
-      const invocation = (operation.func as any)?._value?._attributes;
-      if (!invocation) {
-        return null;
-      }
-
-      const functionName = invocation.functionName?.toString?.();
-      const args = invocation.args as unknown[];
-      if (!Array.isArray(args) || !functionName) {
-        return null;
-      }
-
-      const nativeArgs = args.map((arg) => {
-        try {
-          return StellarSdk.scValToNative(arg as any);
-        } catch {
-          return undefined;
-        }
-      });
-
-      if (functionName === 'create_loan') {
-        return {
-          loanId: nativeArgs[0] as string,
-        };
-      }
-
-      if (functionName === 'repay_loan') {
-        const loanId = nativeArgs[1] as string;
-        const rawAmount = nativeArgs[2];
-        const amount = typeof rawAmount === 'bigint' ? Number(rawAmount) / 10_000_000 :
-          typeof rawAmount === 'number' ? rawAmount / 10_000_000 : undefined;
-
-        return { loanId, amount };
-      }
-
-      return null;
-    } catch (error) {
-      this.logger.warn(
-        {
-          context: 'TransactionStatusCheckerProcessor',
-          action: 'parseTransactionMetadata',
-          error: error?.message,
-          transactionXdr: xdr?.slice(0, 64),
-        },
-        'Failed to parse transaction XDR for follow-up actions',
-      );
-      return null;
-    }
   }
 
   private async createNotification(

--- a/test/fixtures/jobs.fixtures.ts
+++ b/test/fixtures/jobs.fixtures.ts
@@ -1,0 +1,111 @@
+/**
+ * Fixtures for job processor unit tests
+ * (transaction-status-checker, loan-payment-reminder).
+ */
+
+export const CONTRACT_ID_FIXTURE = 'CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR';
+export const USER_WALLET_FIXTURE = 'GB4SHJ6PKMICEIOI3KQCQYFTZEPDOQ7HEYDKWYO7VZZJQGROL2H2KJ5G';
+
+// ---------------------------------------------------------------------------
+// XDR fixtures
+//
+// Generated once via StellarSdk.Contract('...').call(...) + TransactionBuilder
+// and committed as base64 so tests never depend on the SDK's XDR encoder at
+// runtime — only on the decoder path exercised by parseTransactionMetadata.
+// ---------------------------------------------------------------------------
+
+/** invokeHostFunction: create_loan('LOAN-FIXTURE-001', 'MERCHANT-FIXTURE-001', 1000.00, 1000.00, 200.00, 15%, 90d) */
+export const CREATE_LOAN_XDR_FIXTURE =
+  'AAAAAgAAAADccaaJSZTGUyB17AkOLKDnrC7exI9WUZ20P3nX+UuulAAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAABqXkiVAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcAAAALY3JlYXRlX2xvYW4AAAAABwAAAA4AAAAQTE9BTi1GSVhUVVJFLTAwMQAAAA4AAAAUTUVSQ0hBTlQtRklYVFVSRS0wMDEAAAAKAAAAAAAAAAAAAAAAAAGGoAAAAAoAAAAAAAAAAAAAAAAAAYagAAAACgAAAAAAAAAAAAAAAAAATiAAAAADAAAF3AAAAAMAAABaAAAAAAAAAAAAAAAA';
+
+/** invokeHostFunction: repay_loan(user, 'LOAN-FIXTURE-001', 50 XLM in stroops) */
+export const REPAY_LOAN_XDR_FIXTURE =
+  'AAAAAgAAAAASoCPh7zeGHiCY8vPKQpQzzn8cN9L0bbUeb9RTedN/uAAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAABqXkiVAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcAAAAKcmVwYXlfbG9hbgAAAAAAAwAAABIAAAAAAAAAAHkjp89TECIhyNqgKGCzyR43Q+cmBqth365ymBouXo+lAAAADgAAABBMT0FOLUZJWFRVUkUtMDAxAAAACgAAAAAAAAAAAAAAAB3NZQAAAAAAAAAAAAAAAAA=';
+
+/** invokeHostFunction calling an unrecognised contract function */
+export const UNKNOWN_FUNCTION_XDR_FIXTURE =
+  'AAAAAgAAAAAsqZHRYHIkApFzee2eeczXMn43W8a0jpKMYX/JfQgZmQAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAABqXkiVAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcAAAATc29tZV9vdGhlcl9mdW5jdGlvbgAAAAABAAAADgAAAAFYAAAAAAAAAAAAAAAAAAAA';
+
+/** Plain payment operation — no invokeHostFunction at all */
+export const PAYMENT_ONLY_XDR_FIXTURE =
+  'AAAAAgAAAADMUtdRXWX5pURDwLLBezdnW2pEFTFWKizq0UHIwzSudwAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAABqXkiVAAAAAAAAAAEAAAAAAAAAAQAAAAADDFqaqC/doLdJhPiGAHA/4f7iT7LDBmxdj3YoCv0UBwAAAAAAAAAABfXhAAAAAAAAAAAA';
+
+/** Not valid XDR — exercises the parse-failure path */
+export const INVALID_XDR_FIXTURE = 'not-a-real-xdr';
+
+// ---------------------------------------------------------------------------
+// Pending transaction fixtures
+// ---------------------------------------------------------------------------
+
+export interface PendingTransactionFixture {
+  id: string;
+  user_wallet: string;
+  transaction_hash: string;
+  type: 'loan_create' | 'loan_repay' | 'deposit' | 'withdraw';
+  status: 'pending' | 'success' | 'failed';
+  xdr?: string | null;
+  submitted_at: string;
+  updated_at: string;
+}
+
+export function createPendingTransactionFixture(
+  overrides: Partial<PendingTransactionFixture> = {},
+): PendingTransactionFixture {
+  return {
+    id: 'tx-fixture-1',
+    user_wallet: USER_WALLET_FIXTURE,
+    transaction_hash: 'fixture-tx-hash-1',
+    type: 'loan_create',
+    status: 'pending',
+    xdr: CREATE_LOAN_XDR_FIXTURE,
+    submitted_at: '2026-07-13T00:00:00.000Z',
+    updated_at: '2026-07-13T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Active loan fixtures
+// ---------------------------------------------------------------------------
+
+export interface ActiveLoanFixture {
+  id: string;
+  loan_id: string;
+  user_wallet: string;
+  merchant_id: string | null;
+  amount: string;
+  loan_amount: string;
+  next_payment_due: string | null;
+  remaining_balance: string;
+  term: number;
+}
+
+export function createActiveLoanFixture(
+  overrides: Partial<ActiveLoanFixture> = {},
+): ActiveLoanFixture {
+  return {
+    id: 'loan-db-1',
+    loan_id: 'LOAN-1',
+    user_wallet: USER_WALLET_FIXTURE,
+    merchant_id: 'merchant-1',
+    amount: '1000',
+    loan_amount: '1000',
+    next_payment_due: '2026-07-23T00:00:00.000Z',
+    remaining_balance: '500',
+    term: 90,
+    ...overrides,
+  };
+}
+
+/** Builds an ISO due-date string N UTC days offset from a fixed reference date. */
+export function dueDateOffsetDays(referenceDateIso: string, offsetDays: number): string {
+  const reference = new Date(referenceDateIso);
+  const due = new Date(
+    Date.UTC(
+      reference.getUTCFullYear(),
+      reference.getUTCMonth(),
+      reference.getUTCDate() + offsetDays,
+    ),
+  );
+  return due.toISOString();
+}

--- a/test/helpers/job.helpers.ts
+++ b/test/helpers/job.helpers.ts
@@ -1,0 +1,38 @@
+import { Job } from 'bullmq';
+
+/** Minimal BullMQ Job mock — processors only read `id`, `name`, and `data`. */
+export function createMockJob<T = unknown>(overrides: Partial<Job<T>> = {}): Job<T> {
+  return {
+    id: 'job-fixture-1',
+    name: 'test-job',
+    data: {} as T,
+    ...overrides,
+  } as Job<T>;
+}
+
+/**
+ * Creates a fluent mock chain mirroring the Supabase client's chaining API:
+ * from('table').select().eq().single(), etc. Each method returns `this` by
+ * default so chains of arbitrary length don't break; override a specific
+ * method with `mockResolvedValue`/`mockResolvedValueOnce` to control the
+ * terminal result of a given call.
+ */
+export function createSupabaseChainMock(overrides: Record<string, unknown> = {}) {
+  const chain: Record<string, jest.Mock> = {
+    select: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockResolvedValue({ error: null }),
+    update: jest.fn().mockReturnThis(),
+    upsert: jest.fn().mockResolvedValue({ error: null }),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    lt: jest.fn().mockReturnThis(),
+    gte: jest.fn().mockReturnThis(),
+    not: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+    single: jest.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  Object.assign(chain, overrides);
+  return chain;
+}

--- a/test/unit/jobs/loan-payment-reminder/loan-payment-reminder.processor.spec.ts
+++ b/test/unit/jobs/loan-payment-reminder/loan-payment-reminder.processor.spec.ts
@@ -1,0 +1,219 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoanPaymentReminderProcessor } from '../../../../src/jobs/loan-payment-reminder/loan-payment-reminder.processor';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { getReminderWindow } from '../../../../src/jobs/loan-payment-reminder/reminder-window.util';
+import { createMockJob, createSupabaseChainMock } from '../../../helpers/job.helpers';
+import { createActiveLoanFixture, dueDateOffsetDays } from '../../../fixtures/jobs.fixtures';
+
+const NOW_ISO = '2026-07-20T09:00:00.000Z';
+
+describe('LoanPaymentReminderProcessor', () => {
+  let processor: LoanPaymentReminderProcessor;
+
+  let loansChain: ReturnType<typeof createSupabaseChainMock>;
+  let notificationsChain: ReturnType<typeof createSupabaseChainMock>;
+  let merchantsChain: ReturnType<typeof createSupabaseChainMock>;
+
+  const mockSupabaseClient = { from: jest.fn() };
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  };
+
+  function resetChains() {
+    loansChain = createSupabaseChainMock();
+    notificationsChain = createSupabaseChainMock();
+    merchantsChain = createSupabaseChainMock();
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      switch (table) {
+        case 'loans':
+          return loansChain;
+        case 'notifications':
+          return notificationsChain;
+        case 'merchants':
+          return merchantsChain;
+        default:
+          return createSupabaseChainMock();
+      }
+    });
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoanPaymentReminderProcessor,
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    processor = module.get(LoanPaymentReminderProcessor);
+
+    jest.clearAllMocks();
+    mockSupabaseService.getServiceRoleClient.mockReturnValue(mockSupabaseClient);
+    resetChains();
+
+    jest.useFakeTimers().setSystemTime(new Date(NOW_ISO));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should be defined', () => {
+    expect(processor).toBeDefined();
+  });
+
+  // =========================================================================
+  // Reminder window classification (end-to-end through process())
+  // =========================================================================
+
+  describe('3-day reminder window', () => {
+    it('should create a payment_reminder_3d notification for a loan due in 3 days', async () => {
+      const loan = createActiveLoanFixture({
+        next_payment_due: dueDateOffsetDays(NOW_ISO, 3),
+      });
+
+      loansChain.not.mockResolvedValue({ data: [loan], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_wallet: loan.user_wallet,
+          type: 'payment_reminder_3d',
+          title: 'Payment Due in 3 Days',
+        }),
+      );
+    });
+  });
+
+  describe('1-day reminder window', () => {
+    it('should create a payment_reminder_1d notification for a loan due in 1 day', async () => {
+      const loan = createActiveLoanFixture({
+        next_payment_due: dueDateOffsetDays(NOW_ISO, 1),
+      });
+
+      loansChain.not.mockResolvedValue({ data: [loan], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_wallet: loan.user_wallet,
+          type: 'payment_reminder_1d',
+          title: 'Payment Due Tomorrow',
+        }),
+      );
+    });
+  });
+
+  describe('overdue window', () => {
+    it('should create a payment_overdue notification for a loan past its due date', async () => {
+      const loan = createActiveLoanFixture({
+        next_payment_due: dueDateOffsetDays(NOW_ISO, -2),
+      });
+
+      loansChain.not.mockResolvedValue({ data: [loan], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_wallet: loan.user_wallet,
+          type: 'payment_overdue',
+          title: 'Loan Payment Overdue',
+        }),
+      );
+    });
+  });
+
+  describe('outside any reminder window', () => {
+    it('should not create a notification for a loan due in 5 days', async () => {
+      const loan = createActiveLoanFixture({
+        next_payment_due: dueDateOffsetDays(NOW_ISO, 5),
+      });
+
+      loansChain.not.mockResolvedValue({ data: [loan], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(notificationsChain.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Duplicate reminder skip
+  // =========================================================================
+
+  describe('duplicate reminder', () => {
+    it('should skip creating a notification when one was already sent for this loan/window today', async () => {
+      const loan = createActiveLoanFixture({
+        next_payment_due: dueDateOffsetDays(NOW_ISO, 3),
+      });
+
+      loansChain.not.mockResolvedValue({ data: [loan], error: null });
+      notificationsChain.gte.mockResolvedValue({ count: 1, error: null });
+
+      await processor.process(createMockJob());
+
+      expect(notificationsChain.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Completed / inactive loans excluded at the query level
+  // =========================================================================
+
+  describe('completed loans', () => {
+    it('should query only active loans, excluding completed ones from consideration', async () => {
+      loansChain.not.mockResolvedValue({ data: [], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(loansChain.eq).toHaveBeenCalledWith('status', 'active');
+      expect(notificationsChain.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no active loans', () => {
+    it('should skip the run entirely when no active loans are returned', async () => {
+      loansChain.not.mockResolvedValue({ data: [], error: null });
+
+      await expect(processor.process(createMockJob())).resolves.not.toThrow();
+
+      expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('notifications');
+    });
+  });
+});
+
+// ===========================================================================
+// getReminderWindow (pure utility) unit tests
+// ===========================================================================
+
+describe('getReminderWindow', () => {
+  const now = new Date('2026-07-20T09:00:00.000Z');
+
+  it('should return "three-day" when due in exactly 3 days', () => {
+    expect(getReminderWindow(new Date('2026-07-23T00:00:00.000Z'), now)).toBe('three-day');
+  });
+
+  it('should return "one-day" when due in exactly 1 day', () => {
+    expect(getReminderWindow(new Date('2026-07-21T00:00:00.000Z'), now)).toBe('one-day');
+  });
+
+  it('should return "overdue" when the due date is in the past', () => {
+    expect(getReminderWindow(new Date('2026-07-18T00:00:00.000Z'), now)).toBe('overdue');
+  });
+
+  it('should return null when due today', () => {
+    expect(getReminderWindow(new Date('2026-07-20T00:00:00.000Z'), now)).toBeNull();
+  });
+
+  it('should return null when due in 2 days', () => {
+    expect(getReminderWindow(new Date('2026-07-22T00:00:00.000Z'), now)).toBeNull();
+  });
+
+  it('should return null when due in 4 or more days', () => {
+    expect(getReminderWindow(new Date('2026-07-24T00:00:00.000Z'), now)).toBeNull();
+  });
+});

--- a/test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts
+++ b/test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts
@@ -1,0 +1,284 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as StellarSdk from 'stellar-sdk';
+import { TransactionStatusCheckerProcessor } from '../../../../src/jobs/transaction-status-checker/transaction-status-checker.processor';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { createMockJob, createSupabaseChainMock } from '../../../helpers/job.helpers';
+import {
+  CREATE_LOAN_XDR_FIXTURE,
+  REPAY_LOAN_XDR_FIXTURE,
+  INVALID_XDR_FIXTURE,
+  USER_WALLET_FIXTURE,
+  createPendingTransactionFixture,
+} from '../../../fixtures/jobs.fixtures';
+
+describe('TransactionStatusCheckerProcessor', () => {
+  let processor: TransactionStatusCheckerProcessor;
+
+  let transactionsChain: ReturnType<typeof createSupabaseChainMock>;
+  let loansChain: ReturnType<typeof createSupabaseChainMock>;
+  let notificationsChain: ReturnType<typeof createSupabaseChainMock>;
+
+  const mockSupabaseClient = { from: jest.fn() };
+  const mockSupabaseService = {
+    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  };
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue(undefined),
+  };
+
+  function resetChains() {
+    transactionsChain = createSupabaseChainMock();
+    loansChain = createSupabaseChainMock();
+    notificationsChain = createSupabaseChainMock();
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      switch (table) {
+        case 'transactions':
+          return transactionsChain;
+        case 'loans':
+          return loansChain;
+        case 'notifications':
+          return notificationsChain;
+        default:
+          return createSupabaseChainMock();
+      }
+    });
+  }
+
+  /** Horizon's `.transactions().transaction(hash).call()` chain, mocked at the prototype level. */
+  const mockCall = jest.fn();
+  const mockTransactionBuilder = jest.fn().mockReturnValue({ call: mockCall });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionStatusCheckerProcessor,
+        { provide: SupabaseService, useValue: mockSupabaseService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    processor = module.get(TransactionStatusCheckerProcessor);
+
+    jest.clearAllMocks();
+    mockSupabaseService.getServiceRoleClient.mockReturnValue(mockSupabaseClient);
+    mockConfigService.get.mockReturnValue(undefined);
+    resetChains();
+
+    // Retries use real setTimeout back-off — skip the wait so tests stay fast.
+    jest.spyOn(processor as any, 'wait').mockResolvedValue(undefined);
+
+    jest
+      .spyOn(StellarSdk.Horizon.Server.prototype, 'transactions')
+      .mockReturnValue({ transaction: mockTransactionBuilder } as any);
+    mockTransactionBuilder.mockReturnValue({ call: mockCall });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(processor).toBeDefined();
+  });
+
+  // =========================================================================
+  // create_loan follow-up
+  // =========================================================================
+
+  describe('successful create_loan transaction', () => {
+    it('should activate the pending loan and create a success notification', async () => {
+      const tx = createPendingTransactionFixture({
+        type: 'loan_create',
+        xdr: CREATE_LOAN_XDR_FIXTURE,
+      });
+
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockResolvedValue({ successful: true, result_codes: undefined });
+      transactionsChain.single.mockResolvedValue({
+        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
+        error: null,
+      });
+      loansChain.single.mockResolvedValue({
+        data: { loan_id: 'LOAN-FIXTURE-001', status: 'pending' },
+        error: null,
+      });
+
+      await processor.process(createMockJob());
+
+      expect(loansChain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'active' }),
+      );
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_wallet: tx.user_wallet,
+          type: 'loan_create_success',
+          data: expect.objectContaining({ loanId: 'LOAN-FIXTURE-001' }),
+        }),
+      );
+    });
+
+    it('should leave the loan untouched if it is no longer pending', async () => {
+      const tx = createPendingTransactionFixture({ type: 'loan_create', xdr: CREATE_LOAN_XDR_FIXTURE });
+
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockResolvedValue({ successful: true });
+      transactionsChain.single.mockResolvedValue({
+        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
+        error: null,
+      });
+      loansChain.single.mockResolvedValue({
+        data: { loan_id: 'LOAN-FIXTURE-001', status: 'active' },
+        error: null,
+      });
+
+      await processor.process(createMockJob());
+
+      expect(loansChain.update).not.toHaveBeenCalled();
+      expect(notificationsChain.insert).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // repay_loan follow-up
+  // =========================================================================
+
+  describe('successful repay_loan transaction', () => {
+    it('should reduce the remaining balance and create a success notification', async () => {
+      const tx = createPendingTransactionFixture({
+        type: 'loan_repay',
+        xdr: REPAY_LOAN_XDR_FIXTURE,
+      });
+
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockResolvedValue({ successful: true });
+      transactionsChain.single.mockResolvedValue({
+        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
+        error: null,
+      });
+      loansChain.single.mockResolvedValue({
+        data: { remaining_balance: '200', status: 'active' },
+        error: null,
+      });
+
+      await processor.process(createMockJob());
+
+      expect(loansChain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ remaining_balance: 150 }),
+      );
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ user_wallet: tx.user_wallet, type: 'loan_repay_success' }),
+      );
+    });
+
+    it('should mark the loan completed when the repayment clears the balance', async () => {
+      const tx = createPendingTransactionFixture({
+        type: 'loan_repay',
+        xdr: REPAY_LOAN_XDR_FIXTURE,
+      });
+
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockResolvedValue({ successful: true });
+      transactionsChain.single.mockResolvedValue({
+        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
+        error: null,
+      });
+      loansChain.single.mockResolvedValue({
+        data: { remaining_balance: '50', status: 'active' },
+        error: null,
+      });
+
+      await processor.process(createMockJob());
+
+      expect(loansChain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ remaining_balance: 0, status: 'completed' }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // Horizon retry / error handling
+  // =========================================================================
+
+  describe('Horizon transient errors', () => {
+    it('should retry up to the max attempts and continue without throwing', async () => {
+      const tx = createPendingTransactionFixture();
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockRejectedValue(new Error('request timeout'));
+
+      await expect(processor.process(createMockJob())).resolves.not.toThrow();
+
+      expect(mockCall).toHaveBeenCalledTimes(3);
+      expect(transactionsChain.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Horizon 404 not found', () => {
+    it('should leave the transaction pending without retrying or finalizing', async () => {
+      const tx = createPendingTransactionFixture();
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockRejectedValue(new StellarSdk.NotFoundError('Not Found', {} as any));
+
+      await expect(processor.process(createMockJob())).resolves.not.toThrow();
+
+      expect(mockCall).toHaveBeenCalledTimes(1);
+      expect(transactionsChain.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // XDR parse failure
+  // =========================================================================
+
+  describe('XDR parse failure', () => {
+    it('should log and continue gracefully, finalizing with a generic notification', async () => {
+      const tx = createPendingTransactionFixture({
+        type: 'loan_create',
+        xdr: INVALID_XDR_FIXTURE,
+      });
+
+      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
+      mockCall.mockResolvedValue({ successful: true });
+      transactionsChain.single.mockResolvedValue({
+        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
+        error: null,
+      });
+
+      await expect(processor.process(createMockJob())).resolves.not.toThrow();
+
+      // No loanId could be parsed, so no loan lookup/activation happens.
+      expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('loans');
+      expect(notificationsChain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'loan_create_success',
+          data: expect.objectContaining({ loanId: null }),
+        }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // cleanupOldTransactions
+  // =========================================================================
+
+  describe('cleanupOldTransactions', () => {
+    it('should delete non-pending transactions older than 7 days using the correct cutoff', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-20T12:00:00.000Z'));
+
+      transactionsChain.limit.mockResolvedValue({ data: [], error: null });
+
+      await processor.process(createMockJob());
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('transactions');
+      expect(transactionsChain.lt).toHaveBeenCalledWith(
+        'submitted_at',
+        new Date('2026-07-13T12:00:00.000Z').toISOString(),
+      );
+      expect(transactionsChain.neq).toHaveBeenCalledWith('status', 'pending');
+
+      jest.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## 🔗 Related Issue
Closes #121

---

## 🔖 Title
Add unit tests for `TransactionStatusCheckerProcessor` and `LoanPaymentReminderProcessor`

---

## 📝 Description
`test/unit/jobs/` only covered `BlockchainIndexerProcessor`. This PR adds full unit test coverage for the two remaining job processors, plus two small testability refactors requested in the issue (no behavior change — internal only).

---

## 🔄 Changes Made
- [x] Extracted `parseTransactionMetadata` out of `TransactionStatusCheckerProcessor` into a pure, throwing function (`transaction-metadata.util.ts`); the processor now catches and logs the error itself, preserving identical fallback behavior
- [x] Extracted the 3-day/1-day/overdue date-boundary logic out of `LoanPaymentReminderProcessor` into a pure function `getReminderWindow(dueDate, now)` (`reminder-window.util.ts`)
- [x] Added `test/fixtures/jobs.fixtures.ts` — pre-generated `invokeHostFunction` XDR fixtures for `create_loan`/`repay_loan`/unknown-function/payment-only/invalid, plus typed pending-transaction and active-loan factories
- [x] Added `test/helpers/job.helpers.ts` — `createMockJob` and `createSupabaseChainMock` factories
- [x] Added `test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts` (9 tests)
- [x] Added `test/unit/jobs/loan-payment-reminder/loan-payment-reminder.processor.spec.ts` (14 tests)

---

## 📸 Screenshots (if applicable)
N/A — test-only change, no UI impact.

---

## ✅ Test Evidence

### `TransactionStatusCheckerProcessor` — 9/9 passing
```
PASS test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts
  TransactionStatusCheckerProcessor
    ✓ should be defined
    successful create_loan transaction
      ✓ should activate the pending loan and create a success notification
      ✓ should leave the loan untouched if it is no longer pending
    successful repay_loan transaction
      ✓ should reduce the remaining balance and create a success notification
      ✓ should mark the loan completed when the repayment clears the balance
    Horizon transient errors
      ✓ should retry up to the max attempts and continue without throwing
    Horizon 404 not found
      ✓ should leave the transaction pending without retrying or finalizing
    XDR parse failure
      ✓ should log and continue gracefully, finalizing with a generic notification
    cleanupOldTransactions
      ✓ should delete non-pending transactions older than 7 days using the correct cutoff

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Time:        5.128 s
```

### `LoanPaymentReminderProcessor` — 14/14 passing
```
PASS test/unit/jobs/loan-payment-reminder/loan-payment-reminder.processor.spec.ts
  LoanPaymentReminderProcessor
    ✓ should be defined
    3-day reminder window
      ✓ should create a payment_reminder_3d notification for a loan due in 3 days
    1-day reminder window
      ✓ should create a payment_reminder_1d notification for a loan due in 1 day
    overdue window
      ✓ should create a payment_overdue notification for a loan past its due date
    outside any reminder window
      ✓ should not create a notification for a loan due in 5 days
    duplicate reminder
      ✓ should skip creating a notification when one was already sent for this loan/window today
    completed loans
      ✓ should query only active loans, excluding completed ones from consideration
    no active loans
      ✓ should skip the run entirely when no active loans are returned
  getReminderWindow
    ✓ should return "three-day" when due in exactly 3 days
    ✓ should return "one-day" when due in exactly 1 day
    ✓ should return "overdue" when the due date is in the past
    ✓ should return null when due today
    ✓ should return null when due in 2 days
    ✓ should return null when due in 4 or more days

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Time:        4.366 s
```

### Full unit suite — no regressions
```
Test Suites: 20 passed, 20 total
Tests:       250 passed, 250 total
Snapshots:   0 total
Time:        14.002 s
```
(Baseline on `main` before this branch: 227 passed. +23 new tests here, 0 broken.)

### Typecheck
```
$ npx tsc --noEmit -p tsconfig.json
$ echo $?
0
```

### Full e2e suite
Only pre-existing, environment-dependent failures remain (`auth`/`health` require a live Redis connection not available in this sandbox; `reputation` has the unrelated `:wallet` bug tracked separately in #115). None touch the two processors changed here — confirmed by diffing against the same e2e run on `main`.

---

## 🗒️ Additional Notes
- Both refactors are internal-only per the issue's requirement — public API (`process(job)`) is unchanged, and existing tests for both processors' callers pass unmodified.
- `LoanPaymentReminderProcessor` tests use `jest.useFakeTimers().setSystemTime(...)` to make the 3-day/1-day/overdue boundary math deterministic, as suggested in the issue.
- XDR fixtures were generated once via `StellarSdk.Contract(...).call(...)` + `TransactionBuilder` (mirroring `CreditLineContractClient`'s real argument shapes) and committed as base64 strings, so the test suite never depends on the SDK's encoder at runtime — only the decoder path actually exercised by `parseTransactionMetadata`.
- `TransactionStatusCheckerProcessor`'s Horizon client is constructed directly in the constructor (not injected), so tests control it via `jest.spyOn(StellarSdk.Horizon.Server.prototype, 'transactions')` rather than a DI override.
- A couple of the issue's suggested scenarios were adjusted to match actual processor behavior rather than the issue's literal wording: a Horizon 404 leaves the transaction **pending** (not "marked failed" — that only happens for a *confirmed* on-chain failure), and repayment doesn't trigger a reputation update in this processor (that happens separately via on-chain `ScoreChanged` events in `BlockchainIndexerProcessor`). Tests assert the real, documented behavior.