### PR TITLE
feat: create StellarService to centralize Horizon client

### DIFF
--- a/src/blockchain/stellar/stellar.errors.ts
+++ b/src/blockchain/stellar/stellar.errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Normalized error thrown when the Horizon network is unreachable or a
+ * request fails after exhausting all retry attempts.
+ */
+export class StellarNetworkError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'StellarNetworkError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Normalized error thrown when Horizon reports that a transaction hash
+ * could not be found (404).
+ */
+export class TransactionNotFoundError extends Error {
+  readonly hash: string;
+  readonly cause?: unknown;
+
+  constructor(hash: string, cause?: unknown) {
+    super(`Transaction ${hash} was not found on the Stellar network.`);
+    this.name = 'TransactionNotFoundError';
+    this.hash = hash;
+    this.cause = cause;
+  }
+}

--- a/src/blockchain/stellar/stellar.module.ts
+++ b/src/blockchain/stellar/stellar.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { StellarService } from './stellar.service';
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [StellarService],
+  exports: [StellarService],
+})
+export class StellarModule {}

--- a/src/blockchain/stellar/stellar.service.ts
+++ b/src/blockchain/stellar/stellar.service.ts
@@ -55,16 +55,13 @@ export class StellarService {
   /**
    * Submits a signed transaction to the network. Not retried — a submission
    * that reaches Horizon may already have been applied, so retrying could
-   * double-submit.
+   * double-submit. Errors are rethrown as-is (not normalized) since callers
+   * need the raw Horizon result_codes to map to user-facing messages.
    */
   async submitTransaction(
     transaction: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction,
   ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
-    try {
-      return await this.withTimeout(this.horizonServer.submitTransaction(transaction));
-    } catch (error) {
-      throw this.normalizeError(error, 'submitTransaction');
-    }
+    return this.withTimeout(this.horizonServer.submitTransaction(transaction));
   }
 
   /**

--- a/src/blockchain/stellar/stellar.service.ts
+++ b/src/blockchain/stellar/stellar.service.ts
@@ -1,0 +1,193 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as StellarSdk from 'stellar-sdk';
+import { Horizon } from 'stellar-sdk';
+import { StellarNetworkError, TransactionNotFoundError } from './stellar.errors';
+
+const MAX_RETRY_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 500;
+const REQUEST_TIMEOUT_MS = 10000;
+
+export interface HorizonTransactionResponse {
+  hash: string;
+  successful: boolean;
+  ledger_attr?: number;
+  operation_count?: number;
+  source_account?: string;
+  fee_charged?: number | string;
+  memo_type?: string;
+  memo?: string;
+  created_at: string;
+  result_xdr: string;
+  result_codes?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Centralizes the Horizon client used across the app. Wraps every request
+ * with a shared exponential back-off retry policy, a per-request timeout,
+ * and normalized error types so callers no longer need to inspect raw
+ * Horizon/axios error shapes.
+ */
+@Injectable()
+export class StellarService {
+  private readonly logger = new Logger(StellarService.name);
+  private readonly horizonServer: StellarSdk.Horizon.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const horizonUrl =
+      this.configService.get<string>('STELLAR_HORIZON_URL') ||
+      'https://horizon-testnet.stellar.org';
+
+    this.networkPassphrase =
+      this.configService.get<string>('STELLAR_NETWORK_PASSPHRASE') ||
+      StellarSdk.Networks.TESTNET;
+
+    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
+    this.logger.log(`Horizon client initialized: ${horizonUrl}`);
+  }
+
+  getNetworkPassphrase(): string {
+    return this.networkPassphrase;
+  }
+
+  /**
+   * Submits a signed transaction to the network. Not retried — a submission
+   * that reaches Horizon may already have been applied, so retrying could
+   * double-submit.
+   */
+  async submitTransaction(
+    transaction: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction,
+  ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
+    try {
+      return await this.withTimeout(this.horizonServer.submitTransaction(transaction));
+    } catch (error) {
+      throw this.normalizeError(error, 'submitTransaction');
+    }
+  }
+
+  /**
+   * Fetches a transaction by hash, including failed transactions. Retries
+   * transient network errors with exponential back-off; throws
+   * TransactionNotFoundError immediately on a 404 (not retried).
+   */
+  async getTransaction(hash: string): Promise<HorizonTransactionResponse> {
+    return this.withRetry(async () => {
+      try {
+        return (await this.withTimeout(
+          this.horizonServer.transactions().includeFailed(true).transaction(hash).call(),
+        )) as unknown as HorizonTransactionResponse;
+      } catch (error) {
+        if (this.isNotFoundError(error)) {
+          throw new TransactionNotFoundError(hash, error);
+        }
+        throw error;
+      }
+    }, `getTransaction(${hash})`);
+  }
+
+  private async withRetry<T>(operation: () => Promise<T>, context: string): Promise<T> {
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt < MAX_RETRY_ATTEMPTS) {
+      try {
+        return await operation();
+      } catch (error) {
+        if (error instanceof TransactionNotFoundError) {
+          throw error;
+        }
+
+        lastError = error;
+        attempt += 1;
+
+        if (!this.isTransientError(error) || attempt >= MAX_RETRY_ATTEMPTS) {
+          throw this.normalizeError(error, context);
+        }
+
+        const delayMs = this.computeBackoffDelay(attempt);
+        this.logger.warn(
+          `Transient Horizon error on ${context} (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}) — retrying in ${delayMs}ms: ${this.extractMessage(error)}`,
+        );
+        await this.wait(delayMs);
+      }
+    }
+
+    throw this.normalizeError(lastError, context);
+  }
+
+  private computeBackoffDelay(attempt: number): number {
+    const exponentialDelay = BASE_RETRY_DELAY_MS * 2 ** (attempt - 1);
+    const jitter = Math.random() * exponentialDelay * 0.5;
+    return Math.round(exponentialDelay + jitter);
+  }
+
+  private wait(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`Horizon request timed out after ${REQUEST_TIMEOUT_MS}ms`));
+      }, REQUEST_TIMEOUT_MS);
+
+      promise
+        .then((result) => {
+          clearTimeout(timer);
+          resolve(result);
+        })
+        .catch((error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+    });
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    if (error instanceof StellarSdk.NotFoundError) {
+      return true;
+    }
+    const status = (error as { response?: { status?: number } })?.response?.status;
+    return status === 404;
+  }
+
+  private isTransientError(error: unknown): boolean {
+    if (error instanceof StellarSdk.NetworkError) {
+      return true;
+    }
+
+    const status = (error as { response?: { status?: number } })?.response?.status;
+    if (status === 429 || (typeof status === 'number' && status >= 500)) {
+      return true;
+    }
+
+    const message = this.extractMessage(error).toLowerCase();
+    return (
+      message.includes('timeout') ||
+      message.includes('rate limit') ||
+      message.includes('throttl') ||
+      message.includes('temporar') ||
+      message.includes('network') ||
+      message.includes('econnreset') ||
+      message.includes('socket')
+    );
+  }
+
+  private normalizeError(error: unknown, context: string): Error {
+    if (error instanceof TransactionNotFoundError || error instanceof StellarNetworkError) {
+      return error;
+    }
+
+    this.logger.error(`Horizon request failed [${context}]: ${this.extractMessage(error)}`);
+    return new StellarNetworkError(
+      `Stellar network request failed during ${context}: ${this.extractMessage(error)}`,
+      error,
+    );
+  }
+
+  private extractMessage(error: unknown): string {
+    return (error as { message?: string })?.message ?? String(error);
+  }
+}

--- a/src/jobs/transaction-status-checker/transaction-status-checker.module.ts
+++ b/src/jobs/transaction-status-checker/transaction-status-checker.module.ts
@@ -7,10 +7,12 @@ import { SupabaseService } from '../../database/supabase.client';
 import { LoansRepository } from '../../database/repositories/loans.repository';
 import { NotificationsRepository } from '../../database/repositories/notifications.repository';
 import { TransactionsRepository } from '../../database/repositories/transactions.repository';
+import { StellarModule } from '../../blockchain/stellar/stellar.module';
 
 @Module({
   imports: [
     ConfigModule,
+    StellarModule,
     BullModule.registerQueue({ name: 'transaction-status-checker' }),
   ],
   providers: [

--- a/src/jobs/transaction-status-checker/transaction-status-checker.processor.ts
+++ b/src/jobs/transaction-status-checker/transaction-status-checker.processor.ts
@@ -1,13 +1,13 @@
-import { Processor, WorkerHost } from "@nestjs/bullmq";
-import { Logger } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { Job } from "bullmq";
-import * as StellarSdk from "stellar-sdk";
-import { LoansRepository } from "../../database/repositories/loans.repository";
-import { NotificationsRepository } from "../../database/repositories/notifications.repository";
-import { TransactionsRepository } from "../../database/repositories/transactions.repository";
-import { TransactionType } from "../../modules/transactions/dto/submit-transaction-request.dto";
-import { parseTransactionMetadata } from "./transaction-metadata.util";
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { LoansRepository } from '../../database/repositories/loans.repository';
+import { NotificationsRepository } from '../../database/repositories/notifications.repository';
+import { TransactionsRepository } from '../../database/repositories/transactions.repository';
+import { StellarService } from '../../blockchain/stellar/stellar.service';
+import { TransactionNotFoundError } from '../../blockchain/stellar/stellar.errors';
+import { TransactionType } from '../../modules/transactions/dto/submit-transaction-request.dto';
+import { parseTransactionMetadata } from './transaction-metadata.util';
 
 interface PendingTransaction {
   id: string;
@@ -36,27 +36,14 @@ interface FollowUpResult {
 @Processor("transaction-status-checker")
 export class TransactionStatusCheckerProcessor extends WorkerHost {
   private readonly logger = new Logger(TransactionStatusCheckerProcessor.name);
-  private readonly horizonServer: StellarSdk.Horizon.Server;
-  private readonly networkPassphrase: string;
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly stellarService: StellarService,
     private readonly transactionsRepository: TransactionsRepository,
     private readonly loansRepository: LoansRepository,
     private readonly notificationsRepository: NotificationsRepository,
   ) {
     super();
-
-    const horizonUrl =
-      this.configService.get<string>("STELLAR_HORIZON_URL") ||
-      "https://horizon-testnet.stellar.org";
-
-    this.networkPassphrase =
-      this.configService.get<string>("STELLAR_NETWORK_PASSPHRASE") ||
-      StellarSdk.Networks.TESTNET;
-
-    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
-    this.logger.log(`Horizon client initialized: ${horizonUrl}`);
   }
 
   async process(_job: Job): Promise<void> {
@@ -183,51 +170,22 @@ export class TransactionStatusCheckerProcessor extends WorkerHost {
     }));
   }
 
-  private async checkTransactionStatus(
-    hash: string,
-  ): Promise<TransactionStatusResult> {
-    const maxAttempts = 3;
-    let attempt = 0;
-
-    while (attempt < maxAttempts) {
-      try {
-        attempt += 1;
-        const response = await this.horizonServer
-          .transactions()
-          .transaction(hash)
-          .call();
-        return {
-          found: true,
-          successful: response.successful === true,
-          result: response,
-          errorMessage: this.extractHorizonError(response),
-        };
-      } catch (error) {
-        if (this.isNotFoundError(error)) {
-          return { found: false };
-        }
-
-        if (!this.isTransientHorizonError(error) || attempt >= maxAttempts) {
-          throw error;
-        }
-
-        const delayMs = 1000 * attempt;
-        this.logger.warn(
-          {
-            context: "TransactionStatusCheckerProcessor",
-            action: "checkTransactionStatus",
-            transactionHash: hash,
-            attempt,
-            delayMs,
-            error: error?.message,
-          },
-          "Transient Horizon error — retrying",
-        );
-        await this.wait(delayMs);
+  private async checkTransactionStatus(hash: string): Promise<TransactionStatusResult> {
+    try {
+      const response = await this.stellarService.getTransaction(hash);
+      return {
+        found: true,
+        successful: response.successful === true,
+        result: response,
+        errorMessage: this.extractHorizonError(response),
+      };
+    } catch (error) {
+      if (error instanceof TransactionNotFoundError) {
+        return { found: false };
       }
-    }
 
-    return { found: false };
+      throw error;
+    }
   }
 
   private extractHorizonError(response: any): string | undefined {
@@ -245,34 +203,6 @@ export class TransactionStatusCheckerProcessor extends WorkerHost {
     }
 
     return JSON.stringify(codes);
-  }
-
-  private isNotFoundError(error: unknown): boolean {
-    return error instanceof StellarSdk.NotFoundError;
-  }
-
-  private isTransientHorizonError(error: unknown): boolean {
-    if (error instanceof StellarSdk.NetworkError) {
-      return true;
-    }
-
-    const status = (error as any)?.response?.status;
-    if (status === 429 || status >= 500) {
-      return true;
-    }
-
-    const message = String((error as any)?.message ?? "").toLowerCase();
-    return (
-      message.includes("timeout") ||
-      message.includes("rate limit") ||
-      message.includes("throttl") ||
-      message.includes("temporar") ||
-      message.includes("network")
-    );
-  }
-
-  private wait(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private async finalizeTransaction(
@@ -337,7 +267,7 @@ export class TransactionStatusCheckerProcessor extends WorkerHost {
 
     let metadata: ReturnType<typeof parseTransactionMetadata>;
     try {
-      metadata = parseTransactionMetadata(transaction.xdr, this.networkPassphrase);
+      metadata = parseTransactionMetadata(transaction.xdr, this.stellarService.getNetworkPassphrase());
     } catch (error) {
       this.logger.warn(
         {

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -6,12 +6,14 @@ import { TransactionsService } from './transactions.service';
 import { AuthModule } from '../auth/auth.module';
 import { SupabaseService } from '../../database/supabase.client';
 import { TransactionsRepository } from '../../database/repositories/transactions.repository';
+import { StellarModule } from '../../blockchain/stellar/stellar.module';
 import { getRedisConfig } from '../../config/redis.config';
 
 @Module({
   imports: [
     ConfigModule,
     AuthModule,
+    StellarModule,
     CacheModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -6,81 +6,54 @@ import {
   NotFoundException,
   ServiceUnavailableException,
   Logger,
-} from "@nestjs/common";
-import { CACHE_MANAGER } from "@nestjs/cache-manager";
-import { ConfigService } from "@nestjs/config";
-import { Cache } from "cache-manager";
-import * as StellarSdk from "stellar-sdk";
+} from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import * as StellarSdk from 'stellar-sdk';
 import {
   TransactionRecord,
   TransactionsRepository,
-} from "../../database/repositories/transactions.repository";
+} from '../../database/repositories/transactions.repository';
 import {
-  SubmitTransactionRequestDto,
-  TransactionType,
-} from "./dto/submit-transaction-request.dto";
-import { SubmitTransactionResponseDto } from "./dto/submit-transaction-response.dto";
+  HorizonTransactionResponse,
+  StellarService,
+} from '../../blockchain/stellar/stellar.service';
+import { StellarNetworkError, TransactionNotFoundError } from '../../blockchain/stellar/stellar.errors';
+import { SubmitTransactionRequestDto, TransactionType } from './dto/submit-transaction-request.dto';
+import { SubmitTransactionResponseDto } from './dto/submit-transaction-response.dto';
 import {
   TransactionErrorDetailsDto,
   TransactionResultDetailsDto,
   TransactionStatusResponseDto,
-} from "./dto/transaction-status-response.dto";
+} from './dto/transaction-status-response.dto';
 
 const HORIZON_ERROR_MAP: Record<string, string> = {
-  op_bad_auth: "Invalid transaction signature. Please re-sign and try again.",
-  op_no_source_account: "Source account not found on the Stellar network.",
-  op_underfunded:
-    "Insufficient balance to complete one or more operations in this transaction.",
-  tx_bad_seq:
-    "Transaction sequence number is outdated. Please rebuild the transaction.",
-  tx_insufficient_balance: "Insufficient balance to cover this transaction.",
-  tx_bad_auth: "Invalid transaction signature. Please re-sign and try again.",
-  tx_failed: "Transaction failed on the Stellar network.",
-  tx_too_late: "Transaction expired before it could be submitted.",
-  tx_too_early: "Transaction time bounds not yet valid.",
-  tx_insufficient_fee:
-    "Transaction fee is too low to be accepted by the network.",
-  tx_no_account: "Source account does not exist on the Stellar network.",
+  op_bad_auth: 'Invalid transaction signature. Please re-sign and try again.',
+  op_no_source_account: 'Source account not found on the Stellar network.',
+  op_underfunded: 'Insufficient balance to complete one or more operations in this transaction.',
+  tx_bad_seq: 'Transaction sequence number is outdated. Please rebuild the transaction.',
+  tx_insufficient_balance: 'Insufficient balance to cover this transaction.',
+  tx_bad_auth: 'Invalid transaction signature. Please re-sign and try again.',
+  tx_failed: 'Transaction failed on the Stellar network.',
+  tx_too_late: 'Transaction expired before it could be submitted.',
+  tx_too_early: 'Transaction time bounds not yet valid.',
+  tx_insufficient_fee: 'Transaction fee is too low to be accepted by the network.',
+  tx_no_account: 'Source account does not exist on the Stellar network.',
 };
 
-type TransactionStatus = "pending" | "success" | "failed";
-type HorizonTransactionRecord = {
-  hash: string;
-  successful: boolean;
-  ledger_attr: number;
-  operation_count: number;
-  source_account: string;
-  fee_charged: number | string;
-  memo_type: string;
-  memo?: string;
-  created_at: string;
-  result_xdr: string;
-};
+type TransactionStatus = 'pending' | 'success' | 'failed';
 
 const FINALIZED_TRANSACTION_CACHE_TTL = 0;
 
 @Injectable()
 export class TransactionsService {
   private readonly logger = new Logger(TransactionsService.name);
-  private readonly horizonServer: StellarSdk.Horizon.Server;
-  private readonly networkPassphrase: string;
 
   constructor(
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    private readonly configService: ConfigService,
+    private readonly stellarService: StellarService,
     private readonly transactionsRepository: TransactionsRepository,
-  ) {
-    const horizonUrl =
-      this.configService.get<string>("STELLAR_HORIZON_URL") ||
-      "https://horizon-testnet.stellar.org";
-
-    this.networkPassphrase =
-      this.configService.get<string>("STELLAR_NETWORK_PASSPHRASE") ||
-      StellarSdk.Networks.TESTNET;
-
-    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
-    this.logger.log(`Horizon client initialized: ${horizonUrl}`);
-  }
+  ) {}
 
   async submitTransaction(
     wallet: string,
@@ -90,19 +63,13 @@ export class TransactionsService {
 
     let transactionHash: string;
     try {
-      const horizonResult =
-        await this.horizonServer.submitTransaction(transaction);
+      const horizonResult = await this.stellarService.submitTransaction(transaction);
       transactionHash = horizonResult.hash;
     } catch (error) {
       this.handleHorizonError(error);
     }
 
-    this.persistTransactionRecord(
-      wallet,
-      transactionHash,
-      dto.type,
-      dto.xdr,
-    ).catch((err) => {
+    this.persistTransactionRecord(wallet, transactionHash, dto.type, dto.xdr).catch((err) => {
       this.logger.error(
         `Failed to persist transaction record for hash ${transactionHash}: ${err.message}`,
       );
@@ -112,17 +79,14 @@ export class TransactionsService {
       `Transaction submitted — hash: ${transactionHash}, type: ${dto.type}, wallet: ${wallet.slice(0, 8)}...`,
     );
 
-    return { transactionHash, status: "pending" };
+    return { transactionHash, status: 'pending' };
   }
 
-  async getTransactionStatus(
-    hash: string,
-  ): Promise<TransactionStatusResponseDto> {
+  async getTransactionStatus(hash: string): Promise<TransactionStatusResponseDto> {
     const normalizedHash = hash.toLowerCase();
     const cacheKey = `transactions:status:${normalizedHash}`;
 
-    const cached =
-      await this.cacheManager.get<TransactionStatusResponseDto>(cacheKey);
+    const cached = await this.cacheManager.get<TransactionStatusResponseDto>(cacheKey);
     if (cached) {
       return cached;
     }
@@ -130,38 +94,23 @@ export class TransactionsService {
     const transactionRecord = await this.findTransactionRecord(normalizedHash);
 
     try {
-      const horizonTransaction = await this.horizonServer
-        .transactions()
-        .includeFailed(true)
-        .transaction(normalizedHash)
-        .call();
+      const horizonTransaction = await this.stellarService.getTransaction(normalizedHash);
 
-      const response = this.buildFinalizedTransactionResponse(
-        horizonTransaction,
-        transactionRecord,
-      );
+      const response = this.buildFinalizedTransactionResponse(horizonTransaction, transactionRecord);
 
-      await this.cacheManager.set(
-        cacheKey,
-        response,
-        FINALIZED_TRANSACTION_CACHE_TTL,
-      );
+      await this.cacheManager.set(cacheKey, response, FINALIZED_TRANSACTION_CACHE_TTL);
       await this.persistFinalizedTransaction(transactionRecord, response);
 
       return response;
     } catch (error) {
-      if (this.isHorizonNotFoundError(error)) {
+      if (error instanceof TransactionNotFoundError) {
         if (transactionRecord) {
-          return this.buildPendingTransactionResponse(
-            normalizedHash,
-            transactionRecord,
-          );
+          return this.buildPendingTransactionResponse(normalizedHash, transactionRecord);
         }
 
         throw new NotFoundException({
-          code: "TRANSACTION_NOT_FOUND",
-          message:
-            "Transaction hash was not found in Horizon or local records.",
+          code: 'TRANSACTION_NOT_FOUND',
+          message: 'Transaction hash was not found in Horizon or local records.',
         });
       }
 
@@ -169,28 +118,20 @@ export class TransactionsService {
     }
   }
 
-  private parseXdr(
-    xdr: string,
-  ): StellarSdk.Transaction | StellarSdk.FeeBumpTransaction {
+  private parseXdr(xdr: string): StellarSdk.Transaction | StellarSdk.FeeBumpTransaction {
     try {
-      return StellarSdk.TransactionBuilder.fromXDR(xdr, this.networkPassphrase);
+      return StellarSdk.TransactionBuilder.fromXDR(xdr, this.stellarService.getNetworkPassphrase());
     } catch {
       throw new BadRequestException({
-        code: "TRANSACTION_INVALID_XDR",
-        message: "The provided XDR string is malformed or invalid.",
+        code: 'TRANSACTION_INVALID_XDR',
+        message: 'The provided XDR string is malformed or invalid.',
       });
     }
   }
 
   private handleHorizonError(error: unknown): never {
     const err = error as {
-      response?: {
-        data?: {
-          extras?: {
-            result_codes?: { transaction?: string; operations?: string[] };
-          };
-        };
-      };
+      response?: { data?: { extras?: { result_codes?: { transaction?: string; operations?: string[] } } } };
       message?: string;
     };
 
@@ -211,28 +152,23 @@ export class TransactionsService {
       }
 
       throw new BadRequestException({
-        code: "STELLAR_TRANSACTION_FAILED",
-        message: `Transaction rejected by the Stellar network: ${allCodes.join(", ")}`,
+        code: 'STELLAR_TRANSACTION_FAILED',
+        message: `Transaction rejected by the Stellar network: ${allCodes.join(', ')}`,
       });
     }
 
-    const message = err?.message ?? "Unknown error";
-    if (
-      message.toLowerCase().includes("timeout") ||
-      message.toLowerCase().includes("network")
-    ) {
+    const message = err?.message ?? 'Unknown error';
+    if (message.toLowerCase().includes('timeout') || message.toLowerCase().includes('network')) {
       throw new ServiceUnavailableException({
-        code: "STELLAR_NETWORK_UNAVAILABLE",
-        message:
-          "Stellar network is temporarily unavailable. Please try again later.",
+        code: 'STELLAR_NETWORK_UNAVAILABLE',
+        message: 'Stellar network is temporarily unavailable. Please try again later.',
       });
     }
 
     this.logger.error(`Horizon submission error: ${message}`);
     throw new InternalServerErrorException({
-      code: "STELLAR_SUBMISSION_FAILED",
-      message:
-        "Failed to submit transaction to the Stellar network. Please try again.",
+      code: 'STELLAR_SUBMISSION_FAILED',
+      message: 'Failed to submit transaction to the Stellar network. Please try again.',
     });
   }
 
@@ -250,15 +186,13 @@ export class TransactionsService {
     });
   }
 
-  private async findTransactionRecord(
-    hash: string,
-  ): Promise<TransactionRecord | null> {
+  private async findTransactionRecord(hash: string): Promise<TransactionRecord | null> {
     try {
       return await this.transactionsRepository.findByHash(hash);
     } catch {
       throw new InternalServerErrorException({
-        code: "TRANSACTION_LOOKUP_DB_FAILED",
-        message: "Failed to read transaction metadata from the database.",
+        code: 'TRANSACTION_LOOKUP_DB_FAILED',
+        message: 'Failed to read transaction metadata from the database.',
       });
     }
   }
@@ -269,7 +203,7 @@ export class TransactionsService {
   ): TransactionStatusResponseDto {
     return {
       hash,
-      status: "pending",
+      status: 'pending',
       type: transactionRecord.type,
       result: null,
       error: null,
@@ -280,23 +214,17 @@ export class TransactionsService {
   }
 
   private buildFinalizedTransactionResponse(
-    transaction: HorizonTransactionRecord,
+    transaction: HorizonTransactionResponse,
     transactionRecord: TransactionRecord | null,
   ): TransactionStatusResponseDto {
-    const status: TransactionStatus = transaction.successful
-      ? "success"
-      : "failed";
-    const error = transaction.successful
-      ? null
-      : this.extractFailureDetails(transaction.result_xdr);
+    const status: TransactionStatus = transaction.successful ? 'success' : 'failed';
+    const error = transaction.successful ? null : this.extractFailureDetails(transaction.result_xdr);
 
     return {
       hash: transaction.hash.toLowerCase(),
       status,
       type: transactionRecord?.type ?? null,
-      result: transaction.successful
-        ? this.extractSuccessDetails(transaction)
-        : null,
+      result: transaction.successful ? this.extractSuccessDetails(transaction) : null,
       error,
       submittedAt: transactionRecord?.submittedAt ?? null,
       confirmedAt: transaction.created_at,
@@ -305,13 +233,13 @@ export class TransactionsService {
   }
 
   private extractSuccessDetails(
-    transaction: HorizonTransactionRecord,
+    transaction: HorizonTransactionResponse,
   ): TransactionResultDetailsDto {
     return {
       ledger: transaction.ledger_attr,
       operationCount: transaction.operation_count,
       sourceAccount: transaction.source_account,
-      feeCharged: String(transaction.fee_charged),
+      feeCharged: String(transaction.fee_charged ?? ''),
       memoType: transaction.memo_type,
       memo: transaction.memo ?? null,
       createdAt: transaction.created_at,
@@ -320,33 +248,23 @@ export class TransactionsService {
 
   private extractFailureDetails(resultXdr: string): TransactionErrorDetailsDto {
     try {
-      const parsed = StellarSdk.xdr.TransactionResult.fromXDR(
-        resultXdr,
-        "base64",
-      );
+      const parsed = StellarSdk.xdr.TransactionResult.fromXDR(resultXdr, 'base64');
       const txCode = this.toSnakeCase(parsed.result().switch().name);
       const operationResults = parsed.result().value();
       const operationCodes = Array.isArray(operationResults)
-        ? operationResults.map((operationResult) =>
-            this.toSnakeCase(operationResult.switch().name),
-          )
+        ? operationResults.map((operationResult) => this.toSnakeCase(operationResult.switch().name))
         : [];
       const primaryCode = operationCodes[0] ?? txCode;
 
       return {
         code: txCode,
-        message:
-          HORIZON_ERROR_MAP[primaryCode] ??
-          HORIZON_ERROR_MAP[txCode] ??
-          this.humanizeCode(primaryCode),
+        message: HORIZON_ERROR_MAP[primaryCode] ?? HORIZON_ERROR_MAP[txCode] ?? this.humanizeCode(primaryCode),
         operationCodes: operationCodes.length > 0 ? operationCodes : undefined,
       };
     } catch (error) {
-      this.logger.warn(
-        `Failed to parse transaction result XDR: ${(error as Error).message}`,
-      );
+      this.logger.warn(`Failed to parse transaction result XDR: ${(error as Error).message}`);
       return {
-        code: "tx_failed",
+        code: 'tx_failed',
         message: HORIZON_ERROR_MAP.tx_failed,
       };
     }
@@ -382,49 +300,30 @@ export class TransactionsService {
   }
 
   private handleHorizonLookupError(error: unknown, hash: string): never {
-    const err = error as {
-      response?: { status?: number };
-      message?: string;
-    };
-
-    const message = err?.message?.toLowerCase() ?? "";
-    if (
-      err?.response?.status === 502 ||
-      err?.response?.status === 503 ||
-      err?.response?.status === 504 ||
-      message.includes("timeout") ||
-      message.includes("network") ||
-      message.includes("socket")
-    ) {
+    if (error instanceof StellarNetworkError) {
       throw new ServiceUnavailableException({
-        code: "HORIZON_UNAVAILABLE",
+        code: 'HORIZON_UNAVAILABLE',
         message: `Unable to query Horizon for transaction ${hash}. Please try again later.`,
       });
     }
 
-    this.logger.error(
-      `Unexpected Horizon lookup error for ${hash}: ${err?.message ?? error}`,
-    );
+    const message = (error as { message?: string })?.message ?? String(error);
+    this.logger.error(`Unexpected Horizon lookup error for ${hash}: ${message}`);
     throw new InternalServerErrorException({
-      code: "TRANSACTION_STATUS_LOOKUP_FAILED",
-      message: "Failed to retrieve transaction status from Horizon.",
+      code: 'TRANSACTION_STATUS_LOOKUP_FAILED',
+      message: 'Failed to retrieve transaction status from Horizon.',
     });
-  }
-
-  private isHorizonNotFoundError(error: unknown): boolean {
-    const err = error as { response?: { status?: number } };
-    return err?.response?.status === 404;
   }
 
   private toSnakeCase(value: string): string {
     return value
-      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-      .replace(/-/g, "_")
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .replace(/-/g, '_')
       .toLowerCase();
   }
 
   private humanizeCode(code: string): string {
-    const sentence = code.replace(/_/g, " ").trim();
-    return sentence.charAt(0).toUpperCase() + sentence.slice(1) + ".";
+    const sentence = code.replace(/_/g, ' ').trim();
+    return sentence.charAt(0).toUpperCase() + sentence.slice(1) + '.';
   }
 }

--- a/test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts
+++ b/test/unit/jobs/transaction-status-checker/transaction-status-checker.processor.spec.ts
@@ -1,89 +1,63 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
-import * as StellarSdk from 'stellar-sdk';
 import { LoansRepository } from '../../../../src/database/repositories/loans.repository';
 import { NotificationsRepository } from '../../../../src/database/repositories/notifications.repository';
 import { TransactionsRepository } from '../../../../src/database/repositories/transactions.repository';
 import { TransactionStatusCheckerProcessor } from '../../../../src/jobs/transaction-status-checker/transaction-status-checker.processor';
-import { SupabaseService } from '../../../../src/database/supabase.client';
-import { createMockJob, createSupabaseChainMock } from '../../../helpers/job.helpers';
+import { StellarService } from '../../../../src/blockchain/stellar/stellar.service';
+import {
+  StellarNetworkError,
+  TransactionNotFoundError,
+} from '../../../../src/blockchain/stellar/stellar.errors';
+import { createMockJob } from '../../../helpers/job.helpers';
 import {
   CREATE_LOAN_XDR_FIXTURE,
   REPAY_LOAN_XDR_FIXTURE,
   INVALID_XDR_FIXTURE,
-  USER_WALLET_FIXTURE,
   createPendingTransactionFixture,
 } from '../../../fixtures/jobs.fixtures';
 
 describe('TransactionStatusCheckerProcessor', () => {
   let processor: TransactionStatusCheckerProcessor;
 
-  let transactionsChain: ReturnType<typeof createSupabaseChainMock>;
-  let loansChain: ReturnType<typeof createSupabaseChainMock>;
-  let notificationsChain: ReturnType<typeof createSupabaseChainMock>;
-
-  const mockSupabaseClient = { from: jest.fn() };
-  const mockSupabaseService = {
-    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
+  const mockStellarService = {
+    getTransaction: jest.fn(),
+    getNetworkPassphrase: jest.fn().mockReturnValue('Test SDF Network ; September 2015'),
   };
 
-  const mockConfigService = {
-    get: jest.fn().mockReturnValue(undefined),
+  const mockTransactionsRepository = {
+    findPending: jest.fn(),
+    updateStatus: jest.fn(),
+    deleteOlderThan: jest.fn(),
   };
 
-  function resetChains() {
-    transactionsChain = createSupabaseChainMock();
-    loansChain = createSupabaseChainMock();
-    notificationsChain = createSupabaseChainMock();
+  const mockLoansRepository = {
+    findStatusByLoanIdAndWallet: jest.fn(),
+    findBalanceByLoanIdAndWallet: jest.fn(),
+    updateStatus: jest.fn(),
+    updateByLoanIdAndWallet: jest.fn(),
+  };
 
-    mockSupabaseClient.from.mockImplementation((table: string) => {
-      switch (table) {
-        case 'transactions':
-          return transactionsChain;
-        case 'loans':
-          return loansChain;
-        case 'notifications':
-          return notificationsChain;
-        default:
-          return createSupabaseChainMock();
-      }
-    });
-  }
-
-  /** Horizon's `.transactions().transaction(hash).call()` chain, mocked at the prototype level. */
-  const mockCall = jest.fn();
-  const mockTransactionBuilder = jest.fn().mockReturnValue({ call: mockCall });
+  const mockNotificationsRepository = {
+    create: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionStatusCheckerProcessor,
-        { provide: SupabaseService, useValue: mockSupabaseService },
-        { provide: ConfigService, useValue: mockConfigService },
-        TransactionsRepository,
-        LoansRepository,
-        NotificationsRepository,
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: TransactionsRepository, useValue: mockTransactionsRepository },
+        { provide: LoansRepository, useValue: mockLoansRepository },
+        { provide: NotificationsRepository, useValue: mockNotificationsRepository },
       ],
     }).compile();
 
     processor = module.get(TransactionStatusCheckerProcessor);
 
     jest.clearAllMocks();
-    mockSupabaseService.getServiceRoleClient.mockReturnValue(mockSupabaseClient);
-    mockConfigService.get.mockReturnValue(undefined);
-    resetChains();
-
-    // Retries use real setTimeout back-off — skip the wait so tests stay fast.
-    jest.spyOn(processor as any, 'wait').mockResolvedValue(undefined);
-
-    jest
-      .spyOn(StellarSdk.Horizon.Server.prototype, 'transactions')
-      .mockReturnValue({ transaction: mockTransactionBuilder } as any);
-    mockTransactionBuilder.mockReturnValue({ call: mockCall });
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
+    mockStellarService.getNetworkPassphrase.mockReturnValue('Test SDF Network ; September 2015');
+    mockTransactionsRepository.deleteOlderThan.mockResolvedValue(undefined);
+    mockTransactionsRepository.updateStatus.mockResolvedValue(null);
   });
 
   it('should be defined', () => {
@@ -101,23 +75,45 @@ describe('TransactionStatusCheckerProcessor', () => {
         xdr: CREATE_LOAN_XDR_FIXTURE,
       });
 
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockResolvedValue({ successful: true, result_codes: undefined });
-      transactionsChain.maybeSingle.mockResolvedValue({
-        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
-        error: null,
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockResolvedValue({
+        hash: tx.transaction_hash,
+        successful: true,
+        result_codes: undefined,
       });
-      loansChain.maybeSingle.mockResolvedValue({
-        data: { loan_id: 'LOAN-FIXTURE-001', status: 'pending' },
-        error: null,
+      mockTransactionsRepository.updateStatus.mockResolvedValue({
+        id: tx.id,
+        userWallet: tx.user_wallet,
+        hash: tx.transaction_hash,
+        type: tx.type,
+        status: 'success',
+        xdr: tx.xdr,
+      });
+      mockLoansRepository.findStatusByLoanIdAndWallet.mockResolvedValue({
+        loan_id: 'LOAN-FIXTURE-001',
+        status: 'pending',
       });
 
       await processor.process(createMockJob());
 
-      expect(loansChain.update).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'active' }),
+      expect(mockLoansRepository.updateStatus).toHaveBeenCalledWith(
+        'LOAN-FIXTURE-001',
+        tx.user_wallet,
+        'active',
+        'pending',
       );
-      expect(notificationsChain.insert).toHaveBeenCalledWith(
+      expect(mockNotificationsRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           user_wallet: tx.user_wallet,
           type: 'loan_create_success',
@@ -129,21 +125,39 @@ describe('TransactionStatusCheckerProcessor', () => {
     it('should leave the loan untouched if it is no longer pending', async () => {
       const tx = createPendingTransactionFixture({ type: 'loan_create', xdr: CREATE_LOAN_XDR_FIXTURE });
 
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockResolvedValue({ successful: true });
-      transactionsChain.maybeSingle.mockResolvedValue({
-        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
-        error: null,
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockResolvedValue({
+        hash: tx.transaction_hash,
+        successful: true,
       });
-      loansChain.maybeSingle.mockResolvedValue({
-        data: { loan_id: 'LOAN-FIXTURE-001', status: 'active' },
-        error: null,
+      mockTransactionsRepository.updateStatus.mockResolvedValue({
+        id: tx.id,
+        userWallet: tx.user_wallet,
+        hash: tx.transaction_hash,
+        type: tx.type,
+        status: 'success',
+        xdr: tx.xdr,
+      });
+      mockLoansRepository.findStatusByLoanIdAndWallet.mockResolvedValue({
+        loan_id: 'LOAN-FIXTURE-001',
+        status: 'active',
       });
 
       await processor.process(createMockJob());
 
-      expect(loansChain.update).not.toHaveBeenCalled();
-      expect(notificationsChain.insert).toHaveBeenCalled();
+      expect(mockLoansRepository.updateStatus).not.toHaveBeenCalled();
+      expect(mockNotificationsRepository.create).toHaveBeenCalled();
     });
   });
 
@@ -158,23 +172,43 @@ describe('TransactionStatusCheckerProcessor', () => {
         xdr: REPAY_LOAN_XDR_FIXTURE,
       });
 
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockResolvedValue({ successful: true });
-      transactionsChain.maybeSingle.mockResolvedValue({
-        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
-        error: null,
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockResolvedValue({
+        hash: tx.transaction_hash,
+        successful: true,
       });
-      loansChain.maybeSingle.mockResolvedValue({
-        data: { remaining_balance: '200', status: 'active' },
-        error: null,
+      mockTransactionsRepository.updateStatus.mockResolvedValue({
+        id: tx.id,
+        userWallet: tx.user_wallet,
+        hash: tx.transaction_hash,
+        type: tx.type,
+        status: 'success',
+        xdr: tx.xdr,
+      });
+      mockLoansRepository.findBalanceByLoanIdAndWallet.mockResolvedValue({
+        remaining_balance: '200',
+        status: 'active',
       });
 
       await processor.process(createMockJob());
 
-      expect(loansChain.update).toHaveBeenCalledWith(
+      expect(mockLoansRepository.updateByLoanIdAndWallet).toHaveBeenCalledWith(
+        'LOAN-FIXTURE-001',
+        tx.user_wallet,
         expect.objectContaining({ remaining_balance: 150 }),
       );
-      expect(notificationsChain.insert).toHaveBeenCalledWith(
+      expect(mockNotificationsRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({ user_wallet: tx.user_wallet, type: 'loan_repay_success' }),
       );
     });
@@ -185,20 +219,40 @@ describe('TransactionStatusCheckerProcessor', () => {
         xdr: REPAY_LOAN_XDR_FIXTURE,
       });
 
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockResolvedValue({ successful: true });
-      transactionsChain.maybeSingle.mockResolvedValue({
-        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
-        error: null,
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockResolvedValue({
+        hash: tx.transaction_hash,
+        successful: true,
       });
-      loansChain.maybeSingle.mockResolvedValue({
-        data: { remaining_balance: '50', status: 'active' },
-        error: null,
+      mockTransactionsRepository.updateStatus.mockResolvedValue({
+        id: tx.id,
+        userWallet: tx.user_wallet,
+        hash: tx.transaction_hash,
+        type: tx.type,
+        status: 'success',
+        xdr: tx.xdr,
+      });
+      mockLoansRepository.findBalanceByLoanIdAndWallet.mockResolvedValue({
+        remaining_balance: '50',
+        status: 'active',
       });
 
       await processor.process(createMockJob());
 
-      expect(loansChain.update).toHaveBeenCalledWith(
+      expect(mockLoansRepository.updateByLoanIdAndWallet).toHaveBeenCalledWith(
+        'LOAN-FIXTURE-001',
+        tx.user_wallet,
         expect.objectContaining({ remaining_balance: 0, status: 'completed' }),
       );
     });
@@ -209,28 +263,64 @@ describe('TransactionStatusCheckerProcessor', () => {
   // =========================================================================
 
   describe('Horizon transient errors', () => {
-    it('should retry up to the max attempts and continue without throwing', async () => {
+    it('should continue without throwing when StellarService exhausts retries', async () => {
       const tx = createPendingTransactionFixture();
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockRejectedValue(new Error('request timeout'));
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockRejectedValue(
+        new StellarNetworkError('Stellar network request failed'),
+      );
 
       await expect(processor.process(createMockJob())).resolves.not.toThrow();
 
-      expect(mockCall).toHaveBeenCalledTimes(3);
-      expect(transactionsChain.update).not.toHaveBeenCalled();
+      expect(mockStellarService.getTransaction).toHaveBeenCalledWith(tx.transaction_hash);
+      expect(mockTransactionsRepository.updateStatus).not.toHaveBeenCalledWith(
+        tx.transaction_hash,
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ onlyPending: true }),
+      );
     });
   });
 
   describe('Horizon 404 not found', () => {
-    it('should leave the transaction pending without retrying or finalizing', async () => {
+    it('should leave the transaction pending without finalizing', async () => {
       const tx = createPendingTransactionFixture();
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockRejectedValue(new StellarSdk.NotFoundError('Not Found', {} as any));
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockRejectedValue(
+        new TransactionNotFoundError(tx.transaction_hash),
+      );
 
       await expect(processor.process(createMockJob())).resolves.not.toThrow();
 
-      expect(mockCall).toHaveBeenCalledTimes(1);
-      expect(transactionsChain.update).not.toHaveBeenCalled();
+      expect(mockStellarService.getTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTransactionsRepository.updateStatus).not.toHaveBeenCalledWith(
+        tx.transaction_hash,
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ onlyPending: true }),
+      );
     });
   });
 
@@ -245,18 +335,36 @@ describe('TransactionStatusCheckerProcessor', () => {
         xdr: INVALID_XDR_FIXTURE,
       });
 
-      transactionsChain.limit.mockResolvedValue({ data: [tx], error: null });
-      mockCall.mockResolvedValue({ successful: true });
-      transactionsChain.maybeSingle.mockResolvedValue({
-        data: { id: tx.id, user_wallet: tx.user_wallet, transaction_hash: tx.transaction_hash, type: tx.type, xdr: tx.xdr },
-        error: null,
+      mockTransactionsRepository.findPending.mockResolvedValue([
+        {
+          id: tx.id,
+          userWallet: tx.user_wallet,
+          hash: tx.transaction_hash,
+          type: tx.type,
+          status: tx.status,
+          xdr: tx.xdr,
+          submittedAt: tx.submitted_at,
+          updatedAt: tx.updated_at,
+        },
+      ]);
+      mockStellarService.getTransaction.mockResolvedValue({
+        hash: tx.transaction_hash,
+        successful: true,
+      });
+      mockTransactionsRepository.updateStatus.mockResolvedValue({
+        id: tx.id,
+        userWallet: tx.user_wallet,
+        hash: tx.transaction_hash,
+        type: tx.type,
+        status: 'success',
+        xdr: tx.xdr,
       });
 
       await expect(processor.process(createMockJob())).resolves.not.toThrow();
 
       // No loanId could be parsed, so no loan lookup/activation happens.
-      expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('loans');
-      expect(notificationsChain.insert).toHaveBeenCalledWith(
+      expect(mockLoansRepository.findStatusByLoanIdAndWallet).not.toHaveBeenCalled();
+      expect(mockNotificationsRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'loan_create_success',
           data: expect.objectContaining({ loanId: null }),
@@ -273,16 +381,13 @@ describe('TransactionStatusCheckerProcessor', () => {
     it('should delete non-pending transactions older than 7 days using the correct cutoff', async () => {
       jest.useFakeTimers().setSystemTime(new Date('2026-07-20T12:00:00.000Z'));
 
-      transactionsChain.limit.mockResolvedValue({ data: [], error: null });
+      mockTransactionsRepository.findPending.mockResolvedValue([]);
 
       await processor.process(createMockJob());
 
-      expect(mockSupabaseClient.from).toHaveBeenCalledWith('transactions');
-      expect(transactionsChain.lt).toHaveBeenCalledWith(
-        'submitted_at',
+      expect(mockTransactionsRepository.deleteOlderThan).toHaveBeenCalledWith(
         new Date('2026-07-13T12:00:00.000Z').toISOString(),
       );
-      expect(transactionsChain.neq).toHaveBeenCalledWith('status', 'pending');
 
       jest.useRealTimers();
     });

--- a/test/unit/modules/transactions/transactions.service.spec.ts
+++ b/test/unit/modules/transactions/transactions.service.spec.ts
@@ -5,33 +5,16 @@ import {
   NotFoundException,
   ServiceUnavailableException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as StellarSdk from 'stellar-sdk';
 import { TransactionsRepository } from '../../../../src/database/repositories/transactions.repository';
-import { SupabaseService } from '../../../../src/database/supabase.client';
+import { StellarService } from '../../../../src/blockchain/stellar/stellar.service';
+import {
+  StellarNetworkError,
+  TransactionNotFoundError,
+} from '../../../../src/blockchain/stellar/stellar.errors';
 import { TransactionsService } from '../../../../src/modules/transactions/transactions.service';
 import { TransactionType } from '../../../../src/modules/transactions/dto/submit-transaction-request.dto';
-
-const mockTransactionCall = jest.fn();
-const mockIncludeFailed = jest.fn();
-const mockTransactionsBuilder = jest.fn();
-const mockSubmitTransaction = jest.fn();
-
-jest.mock('stellar-sdk', () => {
-  const actual = jest.requireActual('stellar-sdk');
-
-  return {
-    ...actual,
-    Horizon: {
-      ...actual.Horizon,
-      Server: jest.fn().mockImplementation(() => ({
-        submitTransaction: mockSubmitTransaction,
-        transactions: mockTransactionsBuilder,
-      })),
-    },
-  };
-});
 
 describe('TransactionsService', () => {
   let service: TransactionsService;
@@ -45,59 +28,35 @@ describe('TransactionsService', () => {
     set: jest.fn(),
   };
 
-  const mockSupabaseTable = {
-    select: jest.fn(),
-    insert: jest.fn(),
-    update: jest.fn(),
-    eq: jest.fn(),
-    maybeSingle: jest.fn(),
+  const mockStellarService = {
+    submitTransaction: jest.fn(),
+    getTransaction: jest.fn(),
+    getNetworkPassphrase: jest.fn().mockReturnValue(StellarSdk.Networks.TESTNET),
   };
 
-  const mockSupabaseClient = {
-    from: jest.fn().mockReturnValue(mockSupabaseTable),
-  };
-
-  const mockSupabaseService = {
-    getServiceRoleClient: jest.fn().mockReturnValue(mockSupabaseClient),
-  };
-
-  const mockConfigService = {
-    get: jest.fn((key: string) => {
-      if (key === 'STELLAR_HORIZON_URL') return 'https://horizon-testnet.stellar.org';
-      if (key === 'STELLAR_NETWORK_PASSPHRASE') return StellarSdk.Networks.TESTNET;
-      return undefined;
-    }),
+  const mockTransactionsRepository = {
+    create: jest.fn(),
+    findByHash: jest.fn(),
+    updateStatus: jest.fn(),
   };
 
   beforeEach(async () => {
     jest.useFakeTimers().setSystemTime(new Date(now));
-    mockTransactionsBuilder.mockReturnValue({
-      includeFailed: mockIncludeFailed,
-      transaction: mockTransactionCall,
-    });
-    mockIncludeFailed.mockReturnValue({
-      transaction: mockTransactionCall,
-    });
-    mockTransactionCall.mockReturnValue({
-      call: jest.fn(),
-    });
-    mockSupabaseTable.insert.mockResolvedValue({ error: null });
-    mockSupabaseTable.update.mockReturnValue({
-      eq: jest.fn().mockResolvedValue({ error: null }),
-    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionsService,
         { provide: CACHE_MANAGER, useValue: mockCacheManager },
-        { provide: ConfigService, useValue: mockConfigService },
-        { provide: SupabaseService, useValue: mockSupabaseService },
-        TransactionsRepository,
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: TransactionsRepository, useValue: mockTransactionsRepository },
       ],
     }).compile();
 
     service = module.get<TransactionsService>(TransactionsService);
     jest.clearAllMocks();
+    mockStellarService.getNetworkPassphrase.mockReturnValue(StellarSdk.Networks.TESTNET);
+    mockTransactionsRepository.create.mockResolvedValue(undefined);
+    mockTransactionsRepository.updateStatus.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -105,16 +64,31 @@ describe('TransactionsService', () => {
     jest.clearAllMocks();
   });
 
-  function mockDbLookup(record: Record<string, unknown> | null) {
-    mockSupabaseTable.select.mockReturnThis();
-    mockSupabaseTable.eq.mockReturnThis();
-    mockSupabaseTable.maybeSingle.mockResolvedValue({ data: record, error: null });
+  function buildValidXdr(): string {
+    const keypair = StellarSdk.Keypair.random();
+    const account = new StellarSdk.Account(keypair.publicKey(), '0');
+    const tx = new StellarSdk.TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: StellarSdk.Networks.TESTNET,
+    })
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: keypair.publicKey(),
+          asset: StellarSdk.Asset.native(),
+          amount: '1',
+        }),
+      )
+      .setTimeout(30)
+      .build();
+    tx.sign(keypair);
+    return tx.toXDR();
   }
 
-  function mockTxCallResult(result: unknown) {
-    const call = jest.fn().mockResolvedValue(result);
-    mockTransactionCall.mockReturnValue({ call });
-    return call;
+  function buildHorizonResultCodesError(transaction: string, operations: string[] = []): unknown {
+    return {
+      response: { data: { extras: { result_codes: { transaction, operations } } } },
+      message: 'Transaction submission failed',
+    };
   }
 
   it('should return finalized cached responses without calling Horizon', async () => {
@@ -140,20 +114,21 @@ describe('TransactionsService', () => {
     const result = await service.getTransactionStatus(validHash);
 
     expect(result.status).toBe('success');
-    expect(mockTransactionsBuilder).not.toHaveBeenCalled();
+    expect(mockStellarService.getTransaction).not.toHaveBeenCalled();
   });
 
   it('should return and cache a successful finalized transaction', async () => {
     mockCacheManager.get.mockResolvedValue(undefined);
-    mockDbLookup({
+    mockTransactionsRepository.findByHash.mockResolvedValue({
+      lookupColumn: 'hash',
       hash: validHash,
       type: 'loan_repay',
       status: 'pending',
-      submitted_at: '2026-03-23T05:15:00.000Z',
-      completed_at: null,
-      updated_at: '2026-03-23T05:15:10.000Z',
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      completedAt: null,
+      updatedAt: '2026-03-23T05:15:10.000Z',
     });
-    mockTxCallResult({
+    mockStellarService.getTransaction.mockResolvedValue({
       hash: validHash,
       successful: true,
       ledger_attr: 123456,
@@ -189,19 +164,16 @@ describe('TransactionsService', () => {
 
   it('should return pending when Horizon cannot find a locally tracked transaction yet', async () => {
     mockCacheManager.get.mockResolvedValue(undefined);
-    mockDbLookup({
+    mockTransactionsRepository.findByHash.mockResolvedValue({
+      lookupColumn: 'hash',
       hash: validHash,
       type: 'deposit' as TransactionType,
       status: 'pending',
-      submitted_at: '2026-03-23T05:15:00.000Z',
-      completed_at: null,
-      updated_at: '2026-03-23T05:15:10.000Z',
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      completedAt: null,
+      updatedAt: '2026-03-23T05:15:10.000Z',
     });
-    mockTxCallResult(
-      Promise.reject({
-        response: { status: 404 },
-      }),
-    );
+    mockStellarService.getTransaction.mockRejectedValue(new TransactionNotFoundError(validHash));
 
     const result = await service.getTransactionStatus(validHash);
 
@@ -219,25 +191,26 @@ describe('TransactionsService', () => {
 
   it('should return 404 when Horizon cannot find an unknown hash', async () => {
     mockCacheManager.get.mockResolvedValue(undefined);
-    mockDbLookup(null);
-    mockTxCallResult(
-      Promise.reject({
-        response: { status: 404 },
-      }),
-    );
+    mockTransactionsRepository.findByHash.mockResolvedValue(null);
+    mockStellarService.getTransaction.mockRejectedValue(new TransactionNotFoundError(validHash));
 
     await expect(service.getTransactionStatus(validHash)).rejects.toThrow(NotFoundException);
   });
 
   it('should return 503 when Horizon is temporarily unavailable', async () => {
     mockCacheManager.get.mockResolvedValue(undefined);
-    mockDbLookup({
+    mockTransactionsRepository.findByHash.mockResolvedValue({
+      lookupColumn: 'hash',
       hash: validHash,
       type: 'deposit' as TransactionType,
       status: 'pending',
-      submitted_at: '2026-03-23T05:15:00.000Z',
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      completedAt: null,
+      updatedAt: null,
     });
-    mockTxCallResult(Promise.reject(new Error('network timeout')));
+    mockStellarService.getTransaction.mockRejectedValue(
+      new StellarNetworkError('Stellar network request failed'),
+    );
 
     await expect(service.getTransactionStatus(validHash)).rejects.toThrow(
       ServiceUnavailableException,
@@ -246,15 +219,16 @@ describe('TransactionsService', () => {
 
   it('should return failure details and cache finalized failed transactions', async () => {
     mockCacheManager.get.mockResolvedValue(undefined);
-    mockDbLookup({
+    mockTransactionsRepository.findByHash.mockResolvedValue({
+      lookupColumn: 'hash',
       hash: validHash,
       type: 'withdraw' as TransactionType,
       status: 'pending',
-      submitted_at: '2026-03-23T05:15:00.000Z',
-      completed_at: null,
-      updated_at: '2026-03-23T05:15:10.000Z',
+      submittedAt: '2026-03-23T05:15:00.000Z',
+      completedAt: null,
+      updatedAt: '2026-03-23T05:15:10.000Z',
     });
-    mockTxCallResult({
+    mockStellarService.getTransaction.mockResolvedValue({
       hash: validHash,
       successful: false,
       result_xdr: 'AAAA',
@@ -296,42 +270,13 @@ describe('TransactionsService', () => {
     );
   });
 
-  // ── Add this helper alongside the existing mockDbLookup / mockTxCallResult ──
-
-  function buildValidXdr(): string {
-    const keypair = StellarSdk.Keypair.random();
-    const account = new StellarSdk.Account(keypair.publicKey(), '0');
-    const tx = new StellarSdk.TransactionBuilder(account, {
-      fee: '100',
-      networkPassphrase: StellarSdk.Networks.TESTNET,
-    })
-      .addOperation(
-        StellarSdk.Operation.payment({
-          destination: keypair.publicKey(),
-          asset: StellarSdk.Asset.native(),
-          amount: '1',
-        }),
-      )
-      .setTimeout(30)
-      .build();
-    tx.sign(keypair);
-    return tx.toXDR();
-  }
-
-  function buildHorizonResultCodesError(transaction: string, operations: string[] = []): unknown {
-    return {
-      response: { data: { extras: { result_codes: { transaction, operations } } } },
-      message: 'Transaction submission failed',
-    };
-  }
-
   // ══════════════════════════════════════════════════════════════════════════
   // submitTransaction
   // ══════════════════════════════════════════════════════════════════════════
 
   describe('submitTransaction', () => {
     it('returns pending status and the transaction hash on a successful Horizon submission', async () => {
-      mockSubmitTransaction.mockResolvedValue({ hash: validHash });
+      mockStellarService.submitTransaction.mockResolvedValue({ hash: validHash });
 
       const result = await service.submitTransaction(validWallet, {
         xdr: buildValidXdr(),
@@ -339,7 +284,7 @@ describe('TransactionsService', () => {
       });
 
       expect(result).toEqual({ transactionHash: validHash, status: 'pending' });
-      expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+      expect(mockStellarService.submitTransaction).toHaveBeenCalledTimes(1);
     });
 
     it('throws BadRequestException with TRANSACTION_INVALID_XDR when XDR is malformed', async () => {
@@ -352,9 +297,8 @@ describe('TransactionsService', () => {
       ).rejects.toMatchObject({ response: { code: 'TRANSACTION_INVALID_XDR' } });
     });
 
-
     it('throws BadRequestException mapped from a known tx-level result code (tx_bad_auth)', async () => {
-      mockSubmitTransaction.mockRejectedValue(
+      mockStellarService.submitTransaction.mockRejectedValue(
         buildHorizonResultCodesError('tx_bad_auth'),
       );
 
@@ -366,7 +310,7 @@ describe('TransactionsService', () => {
     });
 
     it('throws BadRequestException with STELLAR_TRANSACTION_FAILED for an unmapped result code', async () => {
-      mockSubmitTransaction.mockRejectedValue(
+      mockStellarService.submitTransaction.mockRejectedValue(
         buildHorizonResultCodesError('tx_some_unknown_code'),
       );
 
@@ -378,7 +322,7 @@ describe('TransactionsService', () => {
     });
 
     it('throws ServiceUnavailableException when Horizon submission times out', async () => {
-      mockSubmitTransaction.mockRejectedValue(new Error('network timeout'));
+      mockStellarService.submitTransaction.mockRejectedValue(new Error('network timeout'));
 
       await expect(
         service.submitTransaction(validWallet, { xdr: buildValidXdr(), type: 'deposit' as TransactionType }),
@@ -386,7 +330,7 @@ describe('TransactionsService', () => {
     });
 
     it('throws InternalServerErrorException for an unexpected Horizon submission error', async () => {
-      mockSubmitTransaction.mockRejectedValue(new Error('something unexpected'));
+      mockStellarService.submitTransaction.mockRejectedValue(new Error('something unexpected'));
 
       await expect(
         service.submitTransaction(validWallet, { xdr: buildValidXdr(), type: 'deposit' as TransactionType }),
@@ -401,8 +345,8 @@ describe('TransactionsService', () => {
   describe('getTransactionStatus – additional', () => {
     it('normalises an uppercase hash to lowercase before cache key and DB lookup', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup(null);
-      mockTxCallResult(Promise.reject({ response: { status: 404 } }));
+      mockTransactionsRepository.findByHash.mockResolvedValue(null);
+      mockStellarService.getTransaction.mockRejectedValue(new TransactionNotFoundError(validHash));
 
       await expect(service.getTransactionStatus(validHash.toUpperCase())).rejects.toThrow(
         NotFoundException,
@@ -411,12 +355,13 @@ describe('TransactionsService', () => {
       expect(mockCacheManager.get).toHaveBeenCalledWith(
         `transactions:status:${validHash.toLowerCase()}`,
       );
+      expect(mockTransactionsRepository.findByHash).toHaveBeenCalledWith(validHash.toLowerCase());
     });
 
     it('returns type: null when a finalized transaction has no local DB record', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup(null);
-      mockTxCallResult({
+      mockTransactionsRepository.findByHash.mockResolvedValue(null);
+      mockStellarService.getTransaction.mockResolvedValue({
         hash: validHash,
         successful: true,
         ledger_attr: 1,
@@ -435,32 +380,38 @@ describe('TransactionsService', () => {
       expect(result.type).toBeNull();
     });
 
-    it('throws ServiceUnavailableException when Horizon returns 502 during status lookup', async () => {
+    it('throws ServiceUnavailableException when Horizon lookup fails after retries', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup({ hash: validHash, type: 'deposit' as TransactionType, status: 'pending', submitted_at: now });
-      mockTxCallResult(Promise.reject({ response: { status: 502 } }));
+      mockTransactionsRepository.findByHash.mockResolvedValue({
+        lookupColumn: 'hash',
+        hash: validHash,
+        type: 'deposit' as TransactionType,
+        status: 'pending',
+        submittedAt: now,
+        completedAt: null,
+        updatedAt: null,
+      });
+      mockStellarService.getTransaction.mockRejectedValue(
+        new StellarNetworkError('Stellar network request failed'),
+      );
 
       await expect(service.getTransactionStatus(validHash)).rejects.toThrow(
         ServiceUnavailableException,
       );
     });
 
-    it('throws ServiceUnavailableException when Horizon returns 503 during status lookup', async () => {
+    it('throws InternalServerErrorException for an unexpected status-lookup error', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup({ hash: validHash, type: 'deposit' as TransactionType, status: 'pending', submitted_at: now });
-      mockTxCallResult(Promise.reject({ response: { status: 503 } }));
-
-      await expect(service.getTransactionStatus(validHash)).rejects.toThrow(
-        ServiceUnavailableException,
-      );
-    });
-
-    it('throws InternalServerErrorException for an unexpected Horizon status-lookup error', async () => {
-      mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup({ hash: validHash, type: 'deposit' as TransactionType, status: 'pending', submitted_at: now });
-      mockTxCallResult(
-        Promise.reject({ response: { status: 500 }, message: 'server error' }),
-      );
+      mockTransactionsRepository.findByHash.mockResolvedValue({
+        lookupColumn: 'hash',
+        hash: validHash,
+        type: 'deposit' as TransactionType,
+        status: 'pending',
+        submittedAt: now,
+        completedAt: null,
+        updatedAt: null,
+      });
+      mockStellarService.getTransaction.mockRejectedValue(new Error('unexpected failure'));
 
       await expect(service.getTransactionStatus(validHash)).rejects.toThrow(
         InternalServerErrorException,
@@ -469,8 +420,8 @@ describe('TransactionsService', () => {
 
     it('skips DB persistence when there is no local transaction record', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
-      mockDbLookup(null);
-      mockTxCallResult({
+      mockTransactionsRepository.findByHash.mockResolvedValue(null);
+      mockStellarService.getTransaction.mockResolvedValue({
         hash: validHash,
         successful: true,
         ledger_attr: 1,
@@ -485,37 +436,16 @@ describe('TransactionsService', () => {
 
       await service.getTransactionStatus(validHash);
 
-      expect(mockSupabaseTable.update).not.toHaveBeenCalled();
+      expect(mockTransactionsRepository.updateStatus).not.toHaveBeenCalled();
     });
 
-    it('falls back to transaction_hash column when hash column does not exist in DB', async () => {
+    it('propagates a DB lookup failure as TRANSACTION_LOOKUP_DB_FAILED', async () => {
       mockCacheManager.get.mockResolvedValue(undefined);
+      mockTransactionsRepository.findByHash.mockRejectedValue(new Error('db unreachable'));
 
-      mockSupabaseTable.select.mockReturnThis();
-      mockSupabaseTable.eq.mockReturnThis();
-      mockSupabaseTable.maybeSingle
-        .mockResolvedValueOnce({
-          data: null,
-          error: { message: 'column "hash" does not exist' },
-        })
-        .mockResolvedValueOnce({
-          data: {
-            transaction_hash: validHash,
-            type: 'deposit' as TransactionType,
-            status: 'pending',
-            submitted_at: now,
-            completed_at: null,
-            updated_at: now,
-          },
-          error: null,
-        });
-
-      mockTxCallResult(Promise.reject({ response: { status: 404 } }));
-
-      const result = await service.getTransactionStatus(validHash);
-
-      expect(result.status).toBe('pending');
-      expect(result.type).toBe('deposit');
+      await expect(service.getTransactionStatus(validHash)).rejects.toMatchObject({
+        response: { code: 'TRANSACTION_LOOKUP_DB_FAILED' },
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔗 Related Issue
Closes #117

---

## 🔖 Title
Create StellarService — centralize Horizon client instantiation currently duplicated across modules

---

## 📝 Description
`src/blockchain/stellar/` previously only contained a `.gitkeep` while the Stellar Horizon client was instantiated independently in two places (`TransactionsService` and `TransactionStatusCheckerProcessor`), each with its own retry timing, its own env var reads, and no shared error normalization. This PR adds a single injectable `StellarService` that both consumers now depend on, so retry/back-off logic, timeouts, and error handling live in one place.

---

## 🔄 Changes Made
- [x] Added `StellarNetworkError` / `TransactionNotFoundError` normalized error types in `src/blockchain/stellar/stellar.errors.ts`
- [x] Added `StellarService` in `src/blockchain/stellar/stellar.service.ts` — wraps `Horizon.Server` with a configurable base URL (`ConfigService`), unified exponential back-off retry (max 3 attempts, 500ms base with jitter), a per-request timeout, and normalized errors
- [x] Added `StellarModule`, a `@Global()` NestJS module (same pattern as `SupabaseModule`/`SupabaseService`) exporting `StellarService`
- [x] Refactored `TransactionsService` to inject `StellarService` instead of instantiating `Horizon.Server` inline, mapping normalized errors back to the existing `NotFoundException` / `ServiceUnavailableException` responses
- [x] Refactored `TransactionStatusCheckerProcessor` to inject `StellarService` and removed its duplicated inline retry loop, delegating retry/back-off entirely to the shared service
- [x] Wired `StellarModule` into `TransactionsModule` and `TransactionStatusCheckerModule`
- [x] Updated `transactions.service.spec.ts` and `transaction-status-checker.processor.spec.ts` to mock `StellarService` directly instead of mocking `stellar-sdk` globally
- [x] Removed the stale `.gitkeep` from `src/blockchain/stellar/` now that it contains real source

---

## 📸 Screenshots (if applicable)
N/A — backend service refactor, no UI changes.

---

## 🗒️ Additional Notes
- Rebased onto latest `main` to reconcile with the `TransactionsRepository`/`LoansRepository`/`NotificationsRepository` refactor from #123 — `TransactionsService` and `TransactionStatusCheckerProcessor` now use both the new repositories (DB access) and `StellarService` (Horizon access).
- `npx tsc --noEmit`, `npm run build`, and the full `npx jest` suite (258 tests / 21 suites) all pass.

closes #117