### PR TITLE
Add merchant portfolio, analytics and leaderboard endpoints

### DIFF
--- a/src/database/repositories/loans.repository.ts
+++ b/src/database/repositories/loans.repository.ts
@@ -48,6 +48,24 @@ export interface LoanBalanceRecord {
   status: string;
 }
 
+export interface MerchantLoanStatsRecord {
+  merchant_id: string | null;
+  loan_amount: number | string;
+  remaining_balance: number | string;
+  status: string;
+  created_at: string;
+}
+
+export interface MerchantActiveLoanRecord {
+  id: string;
+  loan_id: string;
+  amount: number | string;
+  remaining_balance: number | string;
+  status: string;
+  next_payment_due: string | null;
+  created_at: string;
+}
+
 @Injectable()
 export class LoansRepository {
   constructor(private readonly supabaseService: SupabaseService) {}
@@ -220,6 +238,64 @@ export class LoansRepository {
       .insert(payment);
 
     this.throwOnError(error);
+  }
+
+  /**
+   * Returns every loan for a single merchant with only the columns
+   * needed for portfolio/analytics/score aggregation.
+   */
+  async findStatsByMerchant(
+    merchantId: string,
+  ): Promise<MerchantLoanStatsRecord[]> {
+    const { data, error } = await this.supabaseService
+      .getServiceRoleClient()
+      .from("loans")
+      .select("merchant_id, loan_amount, remaining_balance, status, created_at")
+      .eq("merchant_id", merchantId);
+
+    this.throwOnError(error);
+    return (data ?? []) as MerchantLoanStatsRecord[];
+  }
+
+  /**
+   * Returns every loan across all merchants with only the columns
+   * needed for leaderboard aggregation.
+   */
+  async findStatsForAllMerchants(): Promise<MerchantLoanStatsRecord[]> {
+    const { data, error } = await this.supabaseService
+      .getServiceRoleClient()
+      .from("loans")
+      .select("merchant_id, loan_amount, remaining_balance, status, created_at")
+      .not("merchant_id", "is", null);
+
+    this.throwOnError(error);
+    return (data ?? []) as MerchantLoanStatsRecord[];
+  }
+
+  /**
+   * Returns a paginated list of a merchant's active loans for the portfolio endpoint.
+   */
+  async findActiveByMerchant(
+    merchantId: string,
+    options: { limit: number; offset: number },
+  ): Promise<{ loans: MerchantActiveLoanRecord[]; total: number }> {
+    const { data, error, count } = await this.supabaseService
+      .getServiceRoleClient()
+      .from("loans")
+      .select(
+        "id, loan_id, amount, remaining_balance, status, next_payment_due, created_at",
+        { count: "exact" },
+      )
+      .eq("merchant_id", merchantId)
+      .eq("status", "active")
+      .order("created_at", { ascending: false })
+      .range(options.offset, options.offset + options.limit - 1);
+
+    this.throwOnError(error);
+    return {
+      loans: (data ?? []) as MerchantActiveLoanRecord[],
+      total: count ?? 0,
+    };
   }
 
   private throwOnError(error: { code?: string; message?: string } | null): void {

--- a/src/database/repositories/merchants.repository.ts
+++ b/src/database/repositories/merchants.repository.ts
@@ -61,6 +61,26 @@ export class MerchantsRepository {
     }
 
     /**
+     * Returns every active merchant, unpaginated, for leaderboard ranking.
+     */
+    async findAllActive(): Promise<MerchantRecord[]> {
+        const { data, error } = await this.supabaseService
+            .getClient()
+            .from('merchants')
+            .select('id, wallet, name, logo, category, is_active')
+            .eq('is_active', true);
+
+        if (error) {
+            throw new InternalServerErrorException({
+                code: 'DATABASE_QUERY_ERROR',
+                message: error.message,
+            });
+        }
+
+        return (data as MerchantRecord[]) ?? [];
+    }
+
+    /**
      * Finds a merchant by its unique ID.
      */
     async findById(id: string): Promise<MerchantDetailRecord | null> {

--- a/src/modules/merchants/dto/merchant-analytics-query.dto.ts
+++ b/src/modules/merchants/dto/merchant-analytics-query.dto.ts
@@ -1,0 +1,19 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class MerchantAnalyticsQueryDto {
+    @ApiPropertyOptional({
+        description: 'Number of trailing months to include in the time-series.',
+        example: 6,
+        default: 6,
+        minimum: 1,
+        maximum: 24,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(24)
+    months?: number = 6;
+}

--- a/src/modules/merchants/dto/merchant-analytics-response.dto.ts
+++ b/src/modules/merchants/dto/merchant-analytics-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MerchantAnalyticsMonthDto {
+    @ApiProperty({ description: 'Calendar month bucket, formatted YYYY-MM.', example: '2026-07' })
+    month: string;
+
+    @ApiProperty({ description: 'Total loan volume originated in this month, in USD.', example: 4200 })
+    volume: number;
+
+    @ApiProperty({ description: 'Number of loans originated in this month.', example: 9 })
+    loanCount: number;
+
+    @ApiProperty({ description: 'Percentage of loans originated in this month that defaulted.', example: 5.5 })
+    defaultRate: number;
+
+    @ApiProperty({ description: 'Average loan size for this month, in USD.', example: 466.67 })
+    avgLoanSize: number;
+}
+
+export class MerchantAnalyticsSummaryDto {
+    @ApiProperty({ description: 'Total loan volume across the requested period, in USD.', example: 25000 })
+    totalVolume: number;
+
+    @ApiProperty({ description: 'Total number of loans across the requested period.', example: 50 })
+    totalLoans: number;
+
+    @ApiProperty({ description: 'Average loan size across the requested period, in USD.', example: 500 })
+    avgLoanSize: number;
+
+    @ApiProperty({ description: 'Percentage of loans that defaulted across the requested period.', example: 6 })
+    defaultRate: number;
+}
+
+export class MerchantAnalyticsResponseDto {
+    @ApiProperty({ description: 'Unique identifier of the merchant.', example: 'merchant-1' })
+    merchantId: string;
+
+    @ApiProperty({ type: [MerchantAnalyticsMonthDto], description: 'Monthly time-series, oldest first.' })
+    months: MerchantAnalyticsMonthDto[];
+
+    @ApiProperty({ type: MerchantAnalyticsSummaryDto })
+    summary: MerchantAnalyticsSummaryDto;
+}

--- a/src/modules/merchants/dto/merchant-leaderboard-query.dto.ts
+++ b/src/modules/merchants/dto/merchant-leaderboard-query.dto.ts
@@ -1,0 +1,50 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export enum MerchantLeaderboardMetric {
+    VOLUME = 'volume',
+    SCORE = 'score',
+    REPAYMENT_RATE = 'repaymentRate',
+    TOTAL_LOANS = 'totalLoans',
+}
+
+export class MerchantLeaderboardQueryDto {
+    @ApiPropertyOptional({
+        description: 'Metric used to rank merchants.',
+        enum: MerchantLeaderboardMetric,
+        default: MerchantLeaderboardMetric.VOLUME,
+        example: MerchantLeaderboardMetric.VOLUME,
+    })
+    @IsOptional()
+    @IsEnum(MerchantLeaderboardMetric, {
+        message: 'metric must be one of: volume, score, repaymentRate, totalLoans',
+    })
+    metric?: MerchantLeaderboardMetric = MerchantLeaderboardMetric.VOLUME;
+
+    @ApiPropertyOptional({
+        description: 'Number of merchants to return per page.',
+        example: 20,
+        default: 20,
+        minimum: 1,
+        maximum: 100,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    limit?: number = 20;
+
+    @ApiPropertyOptional({
+        description: 'Number of ranked merchants to skip before starting to return results.',
+        example: 0,
+        default: 0,
+        minimum: 0,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number = 0;
+}

--- a/src/modules/merchants/dto/merchant-leaderboard-response.dto.ts
+++ b/src/modules/merchants/dto/merchant-leaderboard-response.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ReputationTier } from '../../reputation/dto/reputation-response.dto';
+import { MerchantLeaderboardMetric } from './merchant-leaderboard-query.dto';
+
+export class MerchantLeaderboardEntryDto {
+    @ApiProperty({ description: 'Rank position, 1-indexed, for the selected metric.', example: 1 })
+    rank: number;
+
+    @ApiProperty({ description: 'Unique identifier of the merchant.', example: 'merchant-1' })
+    merchantId: string;
+
+    @ApiProperty({ description: 'Display name of the merchant.', example: 'TechStore' })
+    name: string;
+
+    @ApiProperty({ description: 'URL of the merchant logo image.', example: 'https://example.com/logo.png' })
+    logo: string;
+
+    @ApiProperty({ description: 'Business category of the merchant.', example: 'Electronics' })
+    category: string;
+
+    @ApiProperty({ description: 'Financial score derived from repayment rate, default rate and volume.', example: 87 })
+    score: number;
+
+    @ApiProperty({ description: 'Tier derived from the financial score.', example: 'silver', enum: ['gold', 'silver', 'bronze', 'poor'] })
+    tier: ReputationTier;
+
+    @ApiProperty({ description: 'Total loan volume in USD across the merchant lifetime.', example: 25000 })
+    totalVolume: number;
+
+    @ApiProperty({ description: 'Percentage of loans that were fully repaid.', example: 92.11 })
+    repaymentRate: number;
+
+    @ApiProperty({ description: 'Total number of loans ever created at this merchant.', example: 50 })
+    totalLoans: number;
+}
+
+export class MerchantLeaderboardPaginationDto {
+    @ApiProperty({ example: 20 })
+    limit: number;
+
+    @ApiProperty({ example: 0 })
+    offset: number;
+
+    @ApiProperty({ example: 42 })
+    total: number;
+}
+
+export class MerchantLeaderboardResponseDto {
+    @ApiProperty({ description: 'Metric used to rank the merchants below.', enum: MerchantLeaderboardMetric, example: MerchantLeaderboardMetric.VOLUME })
+    metric: MerchantLeaderboardMetric;
+
+    @ApiProperty({ type: [MerchantLeaderboardEntryDto] })
+    data: MerchantLeaderboardEntryDto[];
+
+    @ApiProperty({ type: MerchantLeaderboardPaginationDto })
+    pagination: MerchantLeaderboardPaginationDto;
+}

--- a/src/modules/merchants/dto/merchant-portfolio-query.dto.ts
+++ b/src/modules/merchants/dto/merchant-portfolio-query.dto.ts
@@ -1,0 +1,31 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class MerchantPortfolioQueryDto {
+    @ApiPropertyOptional({
+        description: 'Number of active loans to return per page.',
+        example: 20,
+        default: 20,
+        minimum: 1,
+        maximum: 100,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    limit?: number = 20;
+
+    @ApiPropertyOptional({
+        description: 'Number of active loans to skip before starting to return results.',
+        example: 0,
+        default: 0,
+        minimum: 0,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number = 0;
+}

--- a/src/modules/merchants/dto/merchant-portfolio-response.dto.ts
+++ b/src/modules/merchants/dto/merchant-portfolio-response.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MerchantPortfolioLoanDto {
+    @ApiProperty({ description: 'Internal UUID of the loan.', example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
+    id: string;
+
+    @ApiProperty({ description: 'On-chain loan identifier.', example: 'loan-123' })
+    loanId: string;
+
+    @ApiProperty({ description: 'Total purchase amount in USD.', example: 500 })
+    amount: number;
+
+    @ApiProperty({ description: 'Current outstanding balance in USD.', example: 324 })
+    remainingBalance: number;
+
+    @ApiProperty({ description: 'Current loan status.', example: 'active' })
+    status: string;
+
+    @ApiProperty({
+        description: 'Next payment due date.',
+        example: '2026-04-13T00:00:00.000Z',
+        nullable: true,
+    })
+    nextPaymentDue: string | null;
+
+    @ApiProperty({ description: 'Loan creation timestamp.', example: '2026-02-13T10:00:00.000Z' })
+    createdAt: string;
+}
+
+export class MerchantPortfolioPaginationDto {
+    @ApiProperty({ example: 20 })
+    limit: number;
+
+    @ApiProperty({ example: 0 })
+    offset: number;
+
+    @ApiProperty({ example: 12 })
+    total: number;
+}
+
+export class MerchantPortfolioResponseDto {
+    @ApiProperty({ description: 'Unique identifier of the merchant.', example: 'merchant-1' })
+    merchantId: string;
+
+    @ApiProperty({ description: 'Total number of loans ever created at this merchant.', example: 50 })
+    totalLoans: number;
+
+    @ApiProperty({ description: 'Number of currently active loans.', example: 12 })
+    activeLoansCount: number;
+
+    @ApiProperty({ description: 'Number of fully repaid loans.', example: 35 })
+    completedLoansCount: number;
+
+    @ApiProperty({ description: 'Number of defaulted loans.', example: 3 })
+    defaultedLoansCount: number;
+
+    @ApiProperty({ description: 'Total loan volume in USD across the merchant lifetime.', example: 25000 })
+    totalVolume: number;
+
+    @ApiProperty({ description: 'Sum of remaining balances across active loans, in USD.', example: 4200 })
+    outstandingBalance: number;
+
+    @ApiProperty({
+        description: 'Percentage of loans that were fully repaid (completedLoans / totalLoans * 100).',
+        example: 92.11,
+    })
+    repaymentRate: number;
+
+    @ApiProperty({ type: [MerchantPortfolioLoanDto], description: 'Paginated list of the merchant active loans.' })
+    activeLoans: MerchantPortfolioLoanDto[];
+
+    @ApiProperty({ type: MerchantPortfolioPaginationDto })
+    pagination: MerchantPortfolioPaginationDto;
+}

--- a/src/modules/merchants/merchant-score.service.ts
+++ b/src/modules/merchants/merchant-score.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { ReputationTier } from '../reputation/dto/reputation-response.dto';
+
+export interface MerchantLoanStatsInput {
+    loan_amount: number | string;
+    remaining_balance: number | string;
+    status: string;
+}
+
+export interface MerchantLoanAggregate {
+    totalLoans: number;
+    activeLoans: number;
+    completedLoans: number;
+    defaultedLoans: number;
+    totalVolume: number;
+    outstandingBalance: number;
+    repaymentRate: number;
+    defaultRate: number;
+}
+
+export interface MerchantScoreResult {
+    score: number;
+    tier: ReputationTier;
+}
+
+const VOLUME_BONUS_DIVISOR = 10_000;
+const MAX_VOLUME_BONUS = 10;
+const REPAYMENT_WEIGHT = 0.9;
+const DEFAULT_PENALTY_WEIGHT = 0.5;
+
+/**
+ * Pure calculation service backing merchant portfolio/analytics/leaderboard
+ * endpoints. Contains no I/O so it can be unit tested without mocking the
+ * database layer.
+ */
+@Injectable()
+export class MerchantScoreService {
+    /**
+     * Reduces a merchant's raw loan rows into portfolio/analytics metrics.
+     */
+    aggregateLoans(loans: MerchantLoanStatsInput[]): MerchantLoanAggregate {
+        const totalLoans = loans.length;
+        let activeLoans = 0;
+        let completedLoans = 0;
+        let defaultedLoans = 0;
+        let totalVolume = 0;
+        let outstandingBalance = 0;
+
+        for (const loan of loans) {
+            totalVolume += Number(loan.loan_amount ?? 0);
+
+            switch (loan.status) {
+                case 'active':
+                    activeLoans += 1;
+                    outstandingBalance += Number(loan.remaining_balance ?? 0);
+                    break;
+                case 'completed':
+                    completedLoans += 1;
+                    break;
+                case 'defaulted':
+                    defaultedLoans += 1;
+                    break;
+            }
+        }
+
+        return {
+            totalLoans,
+            activeLoans,
+            completedLoans,
+            defaultedLoans,
+            totalVolume: this.round(totalVolume),
+            outstandingBalance: this.round(outstandingBalance),
+            repaymentRate: totalLoans > 0 ? this.round((completedLoans / totalLoans) * 100) : 0,
+            defaultRate: totalLoans > 0 ? this.round((defaultedLoans / totalLoans) * 100) : 0,
+        };
+    }
+
+    /**
+     * Derives a 0-100 financial score and tier from a merchant's loan aggregate.
+     * Weighs repayment rate positively, default rate negatively, and gives a
+     * small bonus for loan volume — mirrors the tier thresholds used by
+     * ReputationService (gold >= 90, silver >= 75, bronze >= 60, else poor).
+     */
+    calculateScore(aggregate: MerchantLoanAggregate): MerchantScoreResult {
+        if (aggregate.totalLoans === 0) {
+            return { score: 0, tier: 'poor' };
+        }
+
+        const volumeBonus = Math.min(MAX_VOLUME_BONUS, aggregate.totalVolume / VOLUME_BONUS_DIVISOR);
+        const rawScore =
+            aggregate.repaymentRate * REPAYMENT_WEIGHT -
+            aggregate.defaultRate * DEFAULT_PENALTY_WEIGHT +
+            volumeBonus;
+        const score = Math.max(0, Math.min(100, Math.round(rawScore)));
+
+        return { score, tier: this.mapScoreToTier(score) };
+    }
+
+    private mapScoreToTier(score: number): ReputationTier {
+        if (score >= 90) return 'gold';
+        if (score >= 75) return 'silver';
+        if (score >= 60) return 'bronze';
+        return 'poor';
+    }
+
+    private round(value: number): number {
+        return Math.round(value * 100) / 100;
+    }
+}

--- a/src/modules/merchants/merchants.controller.ts
+++ b/src/modules/merchants/merchants.controller.ts
@@ -1,8 +1,14 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { MerchantsService } from './merchants.service';
 import { ListMerchantsQueryDto } from './dto/list-merchants-query.dto';
 import { MerchantDetailDto } from './dto/merchant-detail.dto';
+import { MerchantPortfolioQueryDto } from './dto/merchant-portfolio-query.dto';
+import { MerchantPortfolioResponseDto } from './dto/merchant-portfolio-response.dto';
+import { MerchantAnalyticsQueryDto } from './dto/merchant-analytics-query.dto';
+import { MerchantAnalyticsResponseDto } from './dto/merchant-analytics-response.dto';
+import { MerchantLeaderboardQueryDto, MerchantLeaderboardMetric } from './dto/merchant-leaderboard-query.dto';
+import { MerchantLeaderboardResponseDto } from './dto/merchant-leaderboard-response.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 
 @ApiTags('Merchants')
@@ -33,6 +39,26 @@ export class MerchantsController {
         };
     }
 
+    @Get('leaderboard')
+    @UseGuards(JwtAuthGuard)
+    @ApiOperation({ summary: 'Get merchants ranked by a configurable metric' })
+    @ApiQuery({ name: 'metric', required: false, enum: MerchantLeaderboardMetric, description: 'Metric used to rank merchants.' })
+    @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Page size (default 20, max 100)' })
+    @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Number of records to skip (default 0)' })
+    @ApiResponse({
+        status: 200,
+        description: 'Merchant leaderboard retrieved successfully.',
+        type: MerchantLeaderboardResponseDto,
+    })
+    @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required.' })
+    async getLeaderboard(@Query() query: MerchantLeaderboardQueryDto): Promise<MerchantLeaderboardResponseDto> {
+        const metric = query.metric ?? MerchantLeaderboardMetric.VOLUME;
+        const limit = query.limit ?? 20;
+        const offset = query.offset ?? 0;
+
+        return this.merchantsService.getLeaderboard(metric, limit, offset);
+    }
+
     @Get(':id')
     @UseGuards(JwtAuthGuard)
     @ApiOperation({ summary: 'Get merchant details by ID or wallet address' })
@@ -50,5 +76,57 @@ export class MerchantsController {
     @ApiResponse({ status: 404, description: 'Merchant not found.' })
     async getMerchantById(@Param('id') id: string): Promise<MerchantDetailDto> {
         return this.merchantsService.getMerchantById(id);
+    }
+
+    @Get(':id/portfolio')
+    @UseGuards(JwtAuthGuard)
+    @ApiOperation({ summary: 'Get a merchant loan portfolio (active loans, repayment rate, volume)' })
+    @ApiParam({
+        name: 'id',
+        description: 'Merchant unique ID (UUID) or Stellar wallet address starting with G.',
+        example: 'merchant-1',
+    })
+    @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Active loans page size (default 20, max 100)' })
+    @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Active loans records to skip (default 0)' })
+    @ApiResponse({
+        status: 200,
+        description: 'Merchant portfolio retrieved successfully.',
+        type: MerchantPortfolioResponseDto,
+    })
+    @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required.' })
+    @ApiResponse({ status: 404, description: 'Merchant not found.' })
+    async getMerchantPortfolio(
+        @Param('id') id: string,
+        @Query() query: MerchantPortfolioQueryDto,
+    ): Promise<MerchantPortfolioResponseDto> {
+        const limit = query.limit ?? 20;
+        const offset = query.offset ?? 0;
+
+        return this.merchantsService.getMerchantPortfolio(id, limit, offset);
+    }
+
+    @Get(':id/analytics')
+    @UseGuards(JwtAuthGuard)
+    @ApiOperation({ summary: 'Get a merchant time-series analytics (volume, default rate, avg loan size)' })
+    @ApiParam({
+        name: 'id',
+        description: 'Merchant unique ID (UUID) or Stellar wallet address starting with G.',
+        example: 'merchant-1',
+    })
+    @ApiQuery({ name: 'months', required: false, type: Number, description: 'Number of trailing months to include (default 6, max 24)' })
+    @ApiResponse({
+        status: 200,
+        description: 'Merchant analytics retrieved successfully.',
+        type: MerchantAnalyticsResponseDto,
+    })
+    @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required.' })
+    @ApiResponse({ status: 404, description: 'Merchant not found.' })
+    async getMerchantAnalytics(
+        @Param('id') id: string,
+        @Query() query: MerchantAnalyticsQueryDto,
+    ): Promise<MerchantAnalyticsResponseDto> {
+        const months = query.months ?? 6;
+
+        return this.merchantsService.getMerchantAnalytics(id, months);
     }
 }

--- a/src/modules/merchants/merchants.module.ts
+++ b/src/modules/merchants/merchants.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MerchantsService } from './merchants.service';
+import { MerchantScoreService } from './merchant-score.service';
 import { MerchantsController } from './merchants.controller';
 import { MerchantsRepository } from '../../database/repositories/merchants.repository';
+import { LoansRepository } from '../../database/repositories/loans.repository';
 import { SupabaseService } from '../../database/supabase.client';
 
 @Module({
     controllers: [MerchantsController],
-    providers: [MerchantsService, MerchantsRepository, SupabaseService],
+    providers: [MerchantsService, MerchantScoreService, MerchantsRepository, LoansRepository, SupabaseService],
     exports: [MerchantsService],
 })
 export class MerchantsModule { }

--- a/src/modules/merchants/merchants.service.ts
+++ b/src/modules/merchants/merchants.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { MerchantDetailRecord, MerchantsRepository } from '../../database/repositories/merchants.repository';
+import { LoansRepository, MerchantLoanStatsRecord } from '../../database/repositories/loans.repository';
+import { MerchantScoreService } from './merchant-score.service';
 import { MerchantDetailDto } from './dto/merchant-detail.dto';
 import { MerchantSummaryDto } from './dto/merchant-summary.dto';
+import { MerchantPortfolioResponseDto } from './dto/merchant-portfolio-response.dto';
+import { MerchantAnalyticsResponseDto } from './dto/merchant-analytics-response.dto';
+import { MerchantLeaderboardMetric } from './dto/merchant-leaderboard-query.dto';
+import { MerchantLeaderboardResponseDto } from './dto/merchant-leaderboard-response.dto';
 
 export interface ListMerchantsResult {
     merchants: MerchantSummaryDto[];
@@ -10,9 +16,23 @@ export interface ListMerchantsResult {
     offset: number;
 }
 
+const LEADERBOARD_METRIC_FIELD: Record<
+    MerchantLeaderboardMetric,
+    'totalVolume' | 'score' | 'repaymentRate' | 'totalLoans'
+> = {
+    [MerchantLeaderboardMetric.VOLUME]: 'totalVolume',
+    [MerchantLeaderboardMetric.SCORE]: 'score',
+    [MerchantLeaderboardMetric.REPAYMENT_RATE]: 'repaymentRate',
+    [MerchantLeaderboardMetric.TOTAL_LOANS]: 'totalLoans',
+};
+
 @Injectable()
 export class MerchantsService {
-    constructor(private readonly merchantsRepository: MerchantsRepository) { }
+    constructor(
+        private readonly merchantsRepository: MerchantsRepository,
+        private readonly loansRepository: LoansRepository,
+        private readonly merchantScoreService: MerchantScoreService,
+    ) { }
 
     /**
      * Returns a paginated list of active merchants.
@@ -72,5 +92,183 @@ export class MerchantsService {
             createdAt: merchant.created_at,
             updatedAt: merchant.updated_at,
         };
+    }
+
+    /**
+     * Returns a merchant's loan portfolio: aggregate volume/repayment metrics
+     * plus a paginated list of its currently active loans.
+     */
+    async getMerchantPortfolio(
+        idOrWallet: string,
+        limit: number,
+        offset: number,
+    ): Promise<MerchantPortfolioResponseDto> {
+        const merchant = await this.resolveMerchant(idOrWallet);
+
+        const [allLoans, { loans: activeLoans, total }] = await Promise.all([
+            this.loansRepository.findStatsByMerchant(merchant.id),
+            this.loansRepository.findActiveByMerchant(merchant.id, { limit, offset }),
+        ]);
+
+        const aggregate = this.merchantScoreService.aggregateLoans(allLoans);
+
+        return {
+            merchantId: merchant.id,
+            totalLoans: aggregate.totalLoans,
+            activeLoansCount: aggregate.activeLoans,
+            completedLoansCount: aggregate.completedLoans,
+            defaultedLoansCount: aggregate.defaultedLoans,
+            totalVolume: aggregate.totalVolume,
+            outstandingBalance: aggregate.outstandingBalance,
+            repaymentRate: aggregate.repaymentRate,
+            activeLoans: activeLoans.map((loan) => ({
+                id: loan.id,
+                loanId: loan.loan_id,
+                amount: Number(loan.amount),
+                remainingBalance: Number(loan.remaining_balance),
+                status: loan.status,
+                nextPaymentDue: loan.next_payment_due,
+                createdAt: loan.created_at,
+            })),
+            pagination: { limit, offset, total },
+        };
+    }
+
+    /**
+     * Returns a merchant's monthly time-series (volume, default rate, avg loan
+     * size) for the trailing N months, plus an aggregate summary.
+     */
+    async getMerchantAnalytics(
+        idOrWallet: string,
+        months: number,
+    ): Promise<MerchantAnalyticsResponseDto> {
+        const merchant = await this.resolveMerchant(idOrWallet);
+        const loans = await this.loansRepository.findStatsByMerchant(merchant.id);
+
+        const buckets = this.buildMonthlyBuckets(months);
+        const monthsData = buckets.map((bucket) => {
+            const loansInBucket = loans.filter((loan) => this.isWithinBucket(loan.created_at, bucket));
+            const aggregate = this.merchantScoreService.aggregateLoans(loansInBucket);
+
+            return {
+                month: bucket.key,
+                volume: aggregate.totalVolume,
+                loanCount: aggregate.totalLoans,
+                defaultRate: aggregate.defaultRate,
+                avgLoanSize: this.averageLoanSize(aggregate.totalVolume, aggregate.totalLoans),
+            };
+        });
+
+        const summaryAggregate = this.merchantScoreService.aggregateLoans(loans);
+
+        return {
+            merchantId: merchant.id,
+            months: monthsData,
+            summary: {
+                totalVolume: summaryAggregate.totalVolume,
+                totalLoans: summaryAggregate.totalLoans,
+                avgLoanSize: this.averageLoanSize(summaryAggregate.totalVolume, summaryAggregate.totalLoans),
+                defaultRate: summaryAggregate.defaultRate,
+            },
+        };
+    }
+
+    /**
+     * Ranks active merchants by a configurable metric (volume, score,
+     * repayment rate, or total loans).
+     */
+    async getLeaderboard(
+        metric: MerchantLeaderboardMetric,
+        limit: number,
+        offset: number,
+    ): Promise<MerchantLeaderboardResponseDto> {
+        const [merchants, allLoans] = await Promise.all([
+            this.merchantsRepository.findAllActive(),
+            this.loansRepository.findStatsForAllMerchants(),
+        ]);
+
+        const loansByMerchant = new Map<string, MerchantLoanStatsRecord[]>();
+        for (const loan of allLoans) {
+            if (!loan.merchant_id) continue;
+            const list = loansByMerchant.get(loan.merchant_id) ?? [];
+            list.push(loan);
+            loansByMerchant.set(loan.merchant_id, list);
+        }
+
+        const field = LEADERBOARD_METRIC_FIELD[metric];
+        const ranked = merchants
+            .map((merchant) => {
+                const aggregate = this.merchantScoreService.aggregateLoans(
+                    loansByMerchant.get(merchant.id) ?? [],
+                );
+                const { score, tier } = this.merchantScoreService.calculateScore(aggregate);
+
+                return {
+                    merchantId: merchant.id,
+                    name: merchant.name,
+                    logo: merchant.logo,
+                    category: merchant.category,
+                    score,
+                    tier,
+                    totalVolume: aggregate.totalVolume,
+                    repaymentRate: aggregate.repaymentRate,
+                    totalLoans: aggregate.totalLoans,
+                };
+            })
+            .sort((a, b) => b[field] - a[field]);
+
+        const total = ranked.length;
+        const data = ranked.slice(offset, offset + limit).map((entry, index) => ({
+            rank: offset + index + 1,
+            ...entry,
+        }));
+
+        return { metric, data, pagination: { limit, offset, total } };
+    }
+
+    /**
+     * Resolves a merchant by ID or wallet address, throwing a structured
+     * NotFoundException ({code, message}) when it doesn't exist.
+     */
+    private async resolveMerchant(idOrWallet: string): Promise<MerchantDetailRecord> {
+        const merchant =
+            idOrWallet.startsWith('G') && idOrWallet.length === 56
+                ? await this.merchantsRepository.findByWallet(idOrWallet)
+                : await this.merchantsRepository.findById(idOrWallet);
+
+        if (!merchant) {
+            throw new NotFoundException({
+                code: 'MERCHANT_NOT_FOUND',
+                message: 'Merchant not found. Please provide a valid merchant ID or wallet address.',
+            });
+        }
+
+        return merchant;
+    }
+
+    private buildMonthlyBuckets(months: number): { key: string; year: number; month: number }[] {
+        const buckets: { key: string; year: number; month: number }[] = [];
+        const now = new Date();
+
+        for (let i = months - 1; i >= 0; i--) {
+            const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+            buckets.push({
+                key: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`,
+                year: date.getFullYear(),
+                month: date.getMonth(),
+            });
+        }
+
+        return buckets;
+    }
+
+    private isWithinBucket(createdAt: string, bucket: { year: number; month: number }): boolean {
+        const date = new Date(createdAt);
+        return date.getFullYear() === bucket.year && date.getMonth() === bucket.month;
+    }
+
+    private averageLoanSize(totalVolume: number, totalLoans: number): number {
+        if (totalLoans === 0) return 0;
+        return Math.round((totalVolume / totalLoans) * 100) / 100;
     }
 }

--- a/test/e2e/modules/merchants/merchants.e2e-spec.ts
+++ b/test/e2e/modules/merchants/merchants.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { NotFoundException, UnauthorizedException, ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { ConfigModule } from '@nestjs/config';
 import { MerchantsModule } from '../../../../src/modules/merchants/merchants.module';
@@ -7,7 +7,8 @@ import { MerchantsService } from '../../../../src/modules/merchants/merchants.se
 import { JwtAuthGuard } from '../../../../src/common/guards/jwt-auth.guard';
 
 /**
- * E2E tests for GET /merchants (API-06) and GET /merchants/:id (API-07).
+ * E2E tests for GET /merchants (API-06), GET /merchants/:id (API-07), and the
+ * merchant portfolio/analytics/leaderboard endpoints (issue #132).
  *
  * JwtAuthGuard is mocked since auth is owned by API-03.
  * We test that:
@@ -31,6 +32,54 @@ describe('MerchantsController (e2e)', () => {
         updatedAt: '2026-01-02T00:00:00Z',
     };
 
+    const merchantPortfolio = {
+        merchantId: 'merchant-1',
+        totalLoans: 2,
+        activeLoansCount: 1,
+        completedLoansCount: 1,
+        defaultedLoansCount: 0,
+        totalVolume: 700,
+        outstandingBalance: 200,
+        repaymentRate: 50,
+        activeLoans: [
+            {
+                id: 'loan-1',
+                loanId: 'chain-loan-1',
+                amount: 400,
+                remainingBalance: 200,
+                status: 'active',
+                nextPaymentDue: '2026-02-01T00:00:00.000Z',
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ],
+        pagination: { limit: 20, offset: 0, total: 1 },
+    };
+
+    const merchantAnalytics = {
+        merchantId: 'merchant-1',
+        months: [{ month: '2026-08', volume: 400, loanCount: 2, defaultRate: 50, avgLoanSize: 200 }],
+        summary: { totalVolume: 400, totalLoans: 2, avgLoanSize: 200, defaultRate: 50 },
+    };
+
+    const merchantLeaderboard = {
+        metric: 'volume',
+        data: [
+            {
+                rank: 1,
+                merchantId: 'merchant-1',
+                name: 'TechStore',
+                logo: 'https://example.com/tech-logo.png',
+                category: 'Electronics',
+                score: 92,
+                tier: 'gold',
+                totalVolume: 20000,
+                repaymentRate: 100,
+                totalLoans: 20,
+            },
+        ],
+        pagination: { limit: 20, offset: 0, total: 1 },
+    };
+
     const mockMerchantsService = {
         listMerchants: jest.fn().mockResolvedValue({
             merchants: [merchantDetail],
@@ -39,6 +88,9 @@ describe('MerchantsController (e2e)', () => {
             offset: 0,
         }),
         getMerchantById: jest.fn().mockResolvedValue(merchantDetail),
+        getMerchantPortfolio: jest.fn().mockResolvedValue(merchantPortfolio),
+        getMerchantAnalytics: jest.fn().mockResolvedValue(merchantAnalytics),
+        getLeaderboard: jest.fn().mockResolvedValue(merchantLeaderboard),
     };
 
     const mockJwtAuthGuard = {
@@ -66,6 +118,15 @@ describe('MerchantsController (e2e)', () => {
             .compile();
 
         app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+        app.useGlobalPipes(
+            new ValidationPipe({
+                whitelist: true,
+                forbidNonWhitelisted: true,
+                transform: true,
+            }),
+        );
+
         await app.init();
         await app.getHttpAdapter().getInstance().ready();
     });
@@ -77,6 +138,9 @@ describe('MerchantsController (e2e)', () => {
     afterEach(() => {
         jest.clearAllMocks();
         mockMerchantsService.getMerchantById.mockResolvedValue(merchantDetail);
+        mockMerchantsService.getMerchantPortfolio.mockResolvedValue(merchantPortfolio);
+        mockMerchantsService.getMerchantAnalytics.mockResolvedValue(merchantAnalytics);
+        mockMerchantsService.getLeaderboard.mockResolvedValue(merchantLeaderboard);
         mockJwtAuthGuard.canActivate.mockImplementation((context) => {
             const req = context.switchToHttp().getRequest();
             const authHeader = req.headers['authorization'];
@@ -132,6 +196,155 @@ describe('MerchantsController (e2e)', () => {
 
             expect(res.statusCode).toBe(401);
             expect(mockMerchantsService.getMerchantById).not.toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------------------
+    // GET /merchants/:id/portfolio
+    // ---------------------------------------------------------------------------
+    describe('GET /merchants/:id/portfolio', () => {
+        it('should return 200 with the merchant portfolio when a valid token and ID are provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/portfolio',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.payload);
+            expect(body).toMatchObject({
+                merchantId: 'merchant-1',
+                totalLoans: 2,
+                repaymentRate: 50,
+            });
+            expect(mockMerchantsService.getMerchantPortfolio).toHaveBeenCalledWith('merchant-1', 20, 0);
+        });
+
+        it('should forward limit/offset query params to the service', async () => {
+            await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/portfolio?limit=5&offset=10',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(mockMerchantsService.getMerchantPortfolio).toHaveBeenCalledWith('merchant-1', 5, 10);
+        });
+
+        it('should return 404 when the merchant is not found', async () => {
+            mockMerchantsService.getMerchantPortfolio.mockRejectedValue(
+                new NotFoundException('Merchant not found'),
+            );
+
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/invalid-id/portfolio',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(res.statusCode).toBe(404);
+        });
+
+        it('should return 401 when no token is provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/portfolio',
+            });
+
+            expect(res.statusCode).toBe(401);
+            expect(mockMerchantsService.getMerchantPortfolio).not.toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------------------
+    // GET /merchants/:id/analytics
+    // ---------------------------------------------------------------------------
+    describe('GET /merchants/:id/analytics', () => {
+        it('should return 200 with the merchant analytics when a valid token and ID are provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/analytics',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.payload);
+            expect(body).toMatchObject({ merchantId: 'merchant-1' });
+            expect(Array.isArray(body.months)).toBe(true);
+            expect(mockMerchantsService.getMerchantAnalytics).toHaveBeenCalledWith('merchant-1', 6);
+        });
+
+        it('should forward the months query param to the service', async () => {
+            await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/analytics?months=12',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(mockMerchantsService.getMerchantAnalytics).toHaveBeenCalledWith('merchant-1', 12);
+        });
+
+        it('should return 404 when the merchant is not found', async () => {
+            mockMerchantsService.getMerchantAnalytics.mockRejectedValue(
+                new NotFoundException('Merchant not found'),
+            );
+
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/invalid-id/analytics',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(res.statusCode).toBe(404);
+        });
+
+        it('should return 401 when no token is provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/merchant-1/analytics',
+            });
+
+            expect(res.statusCode).toBe(401);
+            expect(mockMerchantsService.getMerchantAnalytics).not.toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------------------
+    // GET /merchants/leaderboard
+    // ---------------------------------------------------------------------------
+    describe('GET /merchants/leaderboard', () => {
+        it('should return 200 with the ranked leaderboard when a valid token is provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/leaderboard',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.payload);
+            expect(body.metric).toBe('volume');
+            expect(body.data[0]).toMatchObject({ rank: 1, merchantId: 'merchant-1' });
+            expect(mockMerchantsService.getLeaderboard).toHaveBeenCalledWith('volume', 20, 0);
+        });
+
+        it('should not be shadowed by the GET /merchants/:id route and forward the metric query param', async () => {
+            await app.inject({
+                method: 'GET',
+                url: '/merchants/leaderboard?metric=score&limit=10&offset=5',
+                headers: { authorization: 'Bearer valid.jwt.token' },
+            });
+
+            expect(mockMerchantsService.getLeaderboard).toHaveBeenCalledWith('score', 10, 5);
+            expect(mockMerchantsService.getMerchantById).not.toHaveBeenCalled();
+        });
+
+        it('should return 401 when no token is provided', async () => {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/merchants/leaderboard',
+            });
+
+            expect(res.statusCode).toBe(401);
+            expect(mockMerchantsService.getLeaderboard).not.toHaveBeenCalled();
         });
     });
 });

--- a/test/unit/modules/merchants/merchant-score.service.spec.ts
+++ b/test/unit/modules/merchants/merchant-score.service.spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MerchantScoreService } from '../../../../src/modules/merchants/merchant-score.service';
+
+describe('MerchantScoreService', () => {
+    let service: MerchantScoreService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [MerchantScoreService],
+        }).compile();
+
+        service = module.get<MerchantScoreService>(MerchantScoreService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('aggregateLoans', () => {
+        it('should return all zeros for an empty loan list', () => {
+            const result = service.aggregateLoans([]);
+
+            expect(result).toEqual({
+                totalLoans: 0,
+                activeLoans: 0,
+                completedLoans: 0,
+                defaultedLoans: 0,
+                totalVolume: 0,
+                outstandingBalance: 0,
+                repaymentRate: 0,
+                defaultRate: 0,
+            });
+        });
+
+        it('should count loans by status and sum volume/outstanding balance correctly', () => {
+            const result = service.aggregateLoans([
+                { loan_amount: 400, remaining_balance: 200, status: 'active' },
+                { loan_amount: 300, remaining_balance: 0, status: 'completed' },
+                { loan_amount: 500, remaining_balance: 500, status: 'defaulted' },
+                { loan_amount: 100, remaining_balance: 100, status: 'active' },
+            ]);
+
+            expect(result.totalLoans).toBe(4);
+            expect(result.activeLoans).toBe(2);
+            expect(result.completedLoans).toBe(1);
+            expect(result.defaultedLoans).toBe(1);
+            expect(result.totalVolume).toBe(1300);
+            expect(result.outstandingBalance).toBe(300);
+        });
+
+        it('should compute repaymentRate as completedLoans / totalLoans * 100', () => {
+            const result = service.aggregateLoans([
+                { loan_amount: 100, remaining_balance: 0, status: 'completed' },
+                { loan_amount: 100, remaining_balance: 0, status: 'completed' },
+                { loan_amount: 100, remaining_balance: 0, status: 'completed' },
+                { loan_amount: 100, remaining_balance: 100, status: 'defaulted' },
+            ]);
+
+            expect(result.repaymentRate).toBe(75);
+            expect(result.defaultRate).toBe(25);
+        });
+
+        it('should ignore pending loans when counting active/completed/defaulted but still count them in totalLoans and volume', () => {
+            const result = service.aggregateLoans([
+                { loan_amount: 100, remaining_balance: 100, status: 'pending' },
+                { loan_amount: 200, remaining_balance: 0, status: 'completed' },
+            ]);
+
+            expect(result.totalLoans).toBe(2);
+            expect(result.totalVolume).toBe(300);
+            expect(result.activeLoans).toBe(0);
+            expect(result.completedLoans).toBe(1);
+        });
+
+        it('should coerce string numeric values from the database into numbers', () => {
+            const result = service.aggregateLoans([
+                { loan_amount: '150.5', remaining_balance: '75.25', status: 'active' },
+            ]);
+
+            expect(result.totalVolume).toBe(150.5);
+            expect(result.outstandingBalance).toBe(75.25);
+        });
+    });
+
+    describe('calculateScore', () => {
+        it('should return score 0 and tier poor when there are no loans', () => {
+            const result = service.calculateScore(
+                service.aggregateLoans([]),
+            );
+
+            expect(result).toEqual({ score: 0, tier: 'poor' });
+        });
+
+        it('should assign tier gold to a merchant with a perfect repayment record and high volume', () => {
+            const loans = Array.from({ length: 20 }, () => ({
+                loan_amount: 1000,
+                remaining_balance: 0,
+                status: 'completed' as const,
+            }));
+
+            const { score, tier } = service.calculateScore(service.aggregateLoans(loans));
+
+            expect(tier).toBe('gold');
+            expect(score).toBeGreaterThanOrEqual(90);
+        });
+
+        it('should assign tier poor to a merchant whose loans mostly default', () => {
+            const loans = [
+                { loan_amount: 100, remaining_balance: 100, status: 'defaulted' },
+                { loan_amount: 100, remaining_balance: 100, status: 'defaulted' },
+                { loan_amount: 100, remaining_balance: 100, status: 'defaulted' },
+                { loan_amount: 100, remaining_balance: 0, status: 'completed' },
+            ];
+
+            const { score, tier } = service.calculateScore(service.aggregateLoans(loans));
+
+            expect(tier).toBe('poor');
+            expect(score).toBeLessThan(60);
+        });
+
+        it('should never return a score below 0 or above 100', () => {
+            const manyDefaults = Array.from({ length: 10 }, () => ({
+                loan_amount: 100,
+                remaining_balance: 100,
+                status: 'defaulted' as const,
+            }));
+
+            const { score } = service.calculateScore(service.aggregateLoans(manyDefaults));
+
+            expect(score).toBeGreaterThanOrEqual(0);
+            expect(score).toBeLessThanOrEqual(100);
+        });
+    });
+});

--- a/test/unit/modules/merchants/merchants.service.spec.ts
+++ b/test/unit/modules/merchants/merchants.service.spec.ts
@@ -1,11 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MerchantsService } from '../../../../src/modules/merchants/merchants.service';
 import { MerchantsRepository } from '../../../../src/database/repositories/merchants.repository';
+import { LoansRepository } from '../../../../src/database/repositories/loans.repository';
+import { MerchantScoreService } from '../../../../src/modules/merchants/merchant-score.service';
+import { MerchantLeaderboardMetric } from '../../../../src/modules/merchants/dto/merchant-leaderboard-query.dto';
 import { NotFoundException } from '@nestjs/common';
 
 describe('MerchantsService', () => {
     let service: MerchantsService;
     let repository: jest.Mocked<MerchantsRepository>;
+    let loansRepository: jest.Mocked<LoansRepository>;
 
     const activeMerchants = [
         {
@@ -41,20 +45,30 @@ describe('MerchantsService', () => {
 
     const mockMerchantsRepository = {
         findAll: jest.fn(),
+        findAllActive: jest.fn(),
         findById: jest.fn(),
         findByWallet: jest.fn(),
+    };
+
+    const mockLoansRepository = {
+        findStatsByMerchant: jest.fn(),
+        findStatsForAllMerchants: jest.fn(),
+        findActiveByMerchant: jest.fn(),
     };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 MerchantsService,
+                MerchantScoreService,
                 { provide: MerchantsRepository, useValue: mockMerchantsRepository },
+                { provide: LoansRepository, useValue: mockLoansRepository },
             ],
         }).compile();
 
         service = module.get<MerchantsService>(MerchantsService);
         repository = module.get(MerchantsRepository);
+        loansRepository = module.get(LoansRepository);
     });
 
     afterEach(() => {
@@ -204,6 +218,210 @@ describe('MerchantsService', () => {
             await expect(service.getMerchantById(wallet)).rejects.toThrow(
                 NotFoundException,
             );
+        });
+    });
+
+    describe('getMerchantPortfolio', () => {
+        it('should throw NotFoundException when the merchant does not exist', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(null);
+
+            await expect(service.getMerchantPortfolio('invalid-id', 20, 0)).rejects.toThrow(
+                NotFoundException,
+            );
+        });
+
+        it('should aggregate loan stats and return a paginated list of active loans', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(mockMerchantDetail);
+            mockLoansRepository.findStatsByMerchant.mockResolvedValue([
+                { loan_amount: 400, remaining_balance: 200, status: 'active', created_at: '2026-01-01T00:00:00Z' },
+                { loan_amount: 300, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+            ]);
+            mockLoansRepository.findActiveByMerchant.mockResolvedValue({
+                loans: [
+                    {
+                        id: 'loan-1',
+                        loan_id: 'chain-loan-1',
+                        amount: 400,
+                        remaining_balance: 200,
+                        status: 'active',
+                        next_payment_due: '2026-02-01T00:00:00Z',
+                        created_at: '2026-01-01T00:00:00Z',
+                    },
+                ],
+                total: 1,
+            });
+
+            const result = await service.getMerchantPortfolio('merchant-1', 20, 0);
+
+            expect(loansRepository.findStatsByMerchant).toHaveBeenCalledWith('merchant-1');
+            expect(loansRepository.findActiveByMerchant).toHaveBeenCalledWith('merchant-1', { limit: 20, offset: 0 });
+            expect(result.merchantId).toBe('merchant-1');
+            expect(result.totalLoans).toBe(2);
+            expect(result.activeLoansCount).toBe(1);
+            expect(result.completedLoansCount).toBe(1);
+            expect(result.totalVolume).toBe(700);
+            expect(result.outstandingBalance).toBe(200);
+            expect(result.repaymentRate).toBe(50);
+            expect(result.activeLoans).toEqual([
+                {
+                    id: 'loan-1',
+                    loanId: 'chain-loan-1',
+                    amount: 400,
+                    remainingBalance: 200,
+                    status: 'active',
+                    nextPaymentDue: '2026-02-01T00:00:00Z',
+                    createdAt: '2026-01-01T00:00:00Z',
+                },
+            ]);
+            expect(result.pagination).toEqual({ limit: 20, offset: 0, total: 1 });
+        });
+
+        it('should resolve the merchant by wallet when given a Stellar address', async () => {
+            const wallet = 'GMER1ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJKLMNXX';
+            mockMerchantsRepository.findByWallet.mockResolvedValue(mockMerchantDetail);
+            mockLoansRepository.findStatsByMerchant.mockResolvedValue([]);
+            mockLoansRepository.findActiveByMerchant.mockResolvedValue({ loans: [], total: 0 });
+
+            await service.getMerchantPortfolio(wallet, 20, 0);
+
+            expect(repository.findByWallet).toHaveBeenCalledWith(wallet);
+            expect(repository.findById).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getMerchantAnalytics', () => {
+        it('should throw NotFoundException when the merchant does not exist', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(null);
+
+            await expect(service.getMerchantAnalytics('invalid-id', 6)).rejects.toThrow(
+                NotFoundException,
+            );
+        });
+
+        it('should bucket loans into the requested number of trailing months', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(mockMerchantDetail);
+            mockLoansRepository.findStatsByMerchant.mockResolvedValue([]);
+
+            const result = await service.getMerchantAnalytics('merchant-1', 3);
+
+            expect(result.merchantId).toBe('merchant-1');
+            expect(result.months).toHaveLength(3);
+            expect(result.months[2].month).toBe(
+                `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}`,
+            );
+        });
+
+        it('should compute per-month volume, loanCount, defaultRate and avgLoanSize', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(mockMerchantDetail);
+
+            const now = new Date();
+            const thisMonthIso = new Date(now.getFullYear(), now.getMonth(), 15).toISOString();
+
+            mockLoansRepository.findStatsByMerchant.mockResolvedValue([
+                { loan_amount: 100, remaining_balance: 0, status: 'completed', created_at: thisMonthIso },
+                { loan_amount: 300, remaining_balance: 300, status: 'defaulted', created_at: thisMonthIso },
+            ]);
+
+            const result = await service.getMerchantAnalytics('merchant-1', 1);
+
+            expect(result.months).toHaveLength(1);
+            expect(result.months[0].volume).toBe(400);
+            expect(result.months[0].loanCount).toBe(2);
+            expect(result.months[0].defaultRate).toBe(50);
+            expect(result.months[0].avgLoanSize).toBe(200);
+            expect(result.summary).toEqual({
+                totalVolume: 400,
+                totalLoans: 2,
+                avgLoanSize: 200,
+                defaultRate: 50,
+            });
+        });
+
+        it('should return zeroed buckets when the merchant has no loans', async () => {
+            mockMerchantsRepository.findById.mockResolvedValue(mockMerchantDetail);
+            mockLoansRepository.findStatsByMerchant.mockResolvedValue([]);
+
+            const result = await service.getMerchantAnalytics('merchant-1', 2);
+
+            expect(result.months).toEqual(
+                result.months.map((m) => ({ ...m, volume: 0, loanCount: 0, defaultRate: 0, avgLoanSize: 0 })),
+            );
+            expect(result.summary).toEqual({ totalVolume: 0, totalLoans: 0, avgLoanSize: 0, defaultRate: 0 });
+        });
+    });
+
+    describe('getLeaderboard', () => {
+        it('should rank active merchants by totalVolume by default and assign 1-indexed ranks', async () => {
+            mockMerchantsRepository.findAllActive.mockResolvedValue([
+                { id: 'merchant-1', wallet: 'GMER1', name: 'TechStore', logo: 'logo1.png', category: 'Electronics', is_active: true },
+                { id: 'merchant-2', wallet: 'GMER2', name: 'FashionHub', logo: 'logo2.png', category: 'Clothing', is_active: true },
+            ]);
+            mockLoansRepository.findStatsForAllMerchants.mockResolvedValue([
+                { merchant_id: 'merchant-1', loan_amount: 100, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+                { merchant_id: 'merchant-2', loan_amount: 900, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+            ]);
+
+            const result = await service.getLeaderboard(MerchantLeaderboardMetric.VOLUME, 20, 0);
+
+            expect(result.metric).toBe(MerchantLeaderboardMetric.VOLUME);
+            expect(result.data.map((e) => e.merchantId)).toEqual(['merchant-2', 'merchant-1']);
+            expect(result.data[0].rank).toBe(1);
+            expect(result.data[1].rank).toBe(2);
+            expect(result.pagination).toEqual({ limit: 20, offset: 0, total: 2 });
+        });
+
+        it('should rank merchants by the requested metric', async () => {
+            mockMerchantsRepository.findAllActive.mockResolvedValue([
+                { id: 'merchant-1', wallet: 'GMER1', name: 'TechStore', logo: 'logo1.png', category: 'Electronics', is_active: true },
+                { id: 'merchant-2', wallet: 'GMER2', name: 'FashionHub', logo: 'logo2.png', category: 'Clothing', is_active: true },
+            ]);
+            mockLoansRepository.findStatsForAllMerchants.mockResolvedValue([
+                { merchant_id: 'merchant-1', loan_amount: 900, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+                { merchant_id: 'merchant-2', loan_amount: 100, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+                { merchant_id: 'merchant-2', loan_amount: 100, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+            ]);
+
+            const result = await service.getLeaderboard(MerchantLeaderboardMetric.TOTAL_LOANS, 20, 0);
+
+            expect(result.data.map((e) => e.merchantId)).toEqual(['merchant-2', 'merchant-1']);
+        });
+
+        it('should treat merchants without any loans as having zeroed stats instead of throwing', async () => {
+            mockMerchantsRepository.findAllActive.mockResolvedValue([
+                { id: 'merchant-1', wallet: 'GMER1', name: 'TechStore', logo: 'logo1.png', category: 'Electronics', is_active: true },
+            ]);
+            mockLoansRepository.findStatsForAllMerchants.mockResolvedValue([]);
+
+            const result = await service.getLeaderboard(MerchantLeaderboardMetric.VOLUME, 20, 0);
+
+            expect(result.data[0]).toMatchObject({
+                merchantId: 'merchant-1',
+                score: 0,
+                tier: 'poor',
+                totalVolume: 0,
+                repaymentRate: 0,
+                totalLoans: 0,
+            });
+        });
+
+        it('should apply pagination and offset ranks accordingly', async () => {
+            mockMerchantsRepository.findAllActive.mockResolvedValue([
+                { id: 'merchant-1', wallet: 'GMER1', name: 'A', logo: '', category: '', is_active: true },
+                { id: 'merchant-2', wallet: 'GMER2', name: 'B', logo: '', category: '', is_active: true },
+                { id: 'merchant-3', wallet: 'GMER3', name: 'C', logo: '', category: '', is_active: true },
+            ]);
+            mockLoansRepository.findStatsForAllMerchants.mockResolvedValue([
+                { merchant_id: 'merchant-1', loan_amount: 300, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+                { merchant_id: 'merchant-2', loan_amount: 200, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+                { merchant_id: 'merchant-3', loan_amount: 100, remaining_balance: 0, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+            ]);
+
+            const result = await service.getLeaderboard(MerchantLeaderboardMetric.VOLUME, 1, 1);
+
+            expect(result.data).toHaveLength(1);
+            expect(result.data[0].merchantId).toBe('merchant-2');
+            expect(result.data[0].rank).toBe(2);
+            expect(result.pagination).toEqual({ limit: 1, offset: 1, total: 3 });
         });
     });
 });


### PR DESCRIPTION
## 🔗 Related Issue
Closes #132

---

## 🔖 Title
Add merchant portfolio, analytics and leaderboard endpoints

---

## 📝 Description
`merchants.controller.ts` only exposed `GET /merchants` and `GET /merchants/:id`, so there was no way to inspect a merchant's loan portfolio, repayment performance, or ranking against other merchants. This PR adds three greenfield endpoints plus a pure, unit-testable financial score service backing them.

---

## 🔄 Changes Made
- [x] `GET /merchants/:id/portfolio` — total/active/completed/defaulted loan counts, total volume, outstanding balance, repayment rate, and a paginated list of the merchant's active loans.
- [x] `GET /merchants/:id/analytics` — monthly time-series (volume, default rate, avg loan size) for a configurable trailing window (`months`, default 6, max 24), plus a period summary.
- [x] `GET /merchants/leaderboard` — active merchants ranked by a configurable `metric` (`volume`, `score`, `repaymentRate`, `totalLoans`), paginated. Registered **before** `GET /merchants/:id` so it isn't swallowed by the catch-all ID route.
- [x] `MerchantScoreService` — pure, I/O-free service that aggregates a merchant's raw loan rows (volume, repayment rate, default rate) and derives a 0–100 score + tier (gold/silver/bronze/poor), mirroring `ReputationService`'s existing thresholds.
- [x] New `LoansRepository`/`MerchantsRepository` query methods backing the aggregations (`findStatsByMerchant`, `findStatsForAllMerchants`, `findActiveByMerchant`, `findAllActive`).
- [x] DTOs for every request/response shape, with full Swagger documentation (`@ApiOperation`/`@ApiQuery`/`@ApiParam`/`@ApiResponse`) visible at `/docs`.
- [x] Unit tests: `merchant-score.service.spec.ts` (score/aggregation logic) and extended `merchants.service.spec.ts` (portfolio/analytics/leaderboard orchestration) — 31 tests total.
- [x] Integration tests: extended `merchants.e2e-spec.ts` with 200/404/401 coverage for all three endpoints, query-param forwarding, and a regression test confirming `/leaderboard` isn't shadowed by `/:id` — 14 e2e tests total.

---

## ✅ Manual QA against a live Supabase instance
Ran all three endpoints against the connected Supabase DB (not mocks) with temporary fixture data, then deleted the fixtures afterward — DB is back to its original empty state.

**Setup**: 2 QA merchants (`QA TechStore` — 2 completed + 1 active loan, spread across 3 months; `QA StruggleMart` — 2 defaulted + 1 active loan), signed a real JWT with the project's `JWT_SECRET`.

<details>
<summary><strong>GET /merchants/:id/portfolio</strong> — TechStore</summary>

```json
{
  "merchantId": "5440dc36-...",
  "totalLoans": 3,
  "activeLoansCount": 1,
  "completedLoansCount": 2,
  "defaultedLoansCount": 0,
  "totalVolume": 2160,
  "outstandingBalance": 210,
  "repaymentRate": 66.67,
  "activeLoans": [{ "id": "a61a3b36-...", "amount": 500, "remainingBalance": 210, "status": "active", ... }],
  "pagination": { "limit": 20, "offset": 0, "total": 1 }
}
```
Matches the seed data exactly (2/3 completed = 66.67%, volume = 800+960+400).
</details>

<details>
<summary><strong>GET /merchants/:id/analytics?months=3</strong> — TechStore</summary>

```json
{
  "merchantId": "5440dc36-...",
  "months": [
    { "month": "2026-06", "volume": 800,  "loanCount": 1, "defaultRate": 0, "avgLoanSize": 800 },
    { "month": "2026-07", "volume": 960,  "loanCount": 1, "defaultRate": 0, "avgLoanSize": 960 },
    { "month": "2026-08", "volume": 400,  "loanCount": 1, "defaultRate": 0, "avgLoanSize": 400 }
  ],
  "summary": { "totalVolume": 2160, "totalLoans": 3, "avgLoanSize": 720, "defaultRate": 0 }
}
```
Each seeded loan landed in the correct month bucket, oldest first.
</details>

<details>
<summary><strong>GET /merchants/leaderboard</strong> — all four metrics</summary>

TechStore (score 60, bronze, 66.67% repayment) consistently ranks #1 over StruggleMart (score 0, poor, 0% repayment) across `volume`, `score`, `repaymentRate`, and `totalLoans`, with correct 1-indexed `rank` and `pagination`.
</details>

<details>
<summary><strong>Auth / not-found / routing edge cases</strong></summary>

| Check | Result |
|---|---|
| No `Authorization` header on all 3 new endpoints | `401` |
| Unknown merchant ID on `/portfolio` and `/analytics` | `404` with `{"code":"MERCHANT_NOT_FOUND", ...}` |
| `GET /merchants/leaderboard` (no path param) | `200` with leaderboard payload — **not** routed to `GET /merchants/:id` |

</details>

**Note**: manual testing required bypassing two pre-existing, unrelated issues on `main` so the app could boot at all — a `@fastify/helmet` v13/fastify v4 version mismatch in `src/main.ts`, and no local Redis for BullMQ. Neither was touched by this PR; they block `npm run start:dev` for everyone on `main` today and are worth a separate fix.

---

## 🗒️ Additional Notes
- The financial score formula (repayment rate weighted 0.9, default rate penalized 0.5, small volume bonus capped at +10, mapped to the same gold/silver/bronze/poor tiers as `ReputationService`) is a reasonable-but-arbitrary choice — the issue didn't specify an exact formula. Happy to adjust weights if maintainers have a preferred model.
- `/leaderboard` and `/:id/portfolio`/`/:id/analytics` do client-side aggregation over a merchant's loan rows (same pattern as the existing `LiquidityRepository`), rather than a DB view, since no aggregation views exist anywhere else in this codebase yet.
- No repository-level unit tests were added (`loans.repository.ts`/`merchants.repository.ts`) since the existing `repositories.spec.ts` only smoke-tests a handful of methods, not every one — the new queries are already exercised indirectly through the service unit tests (mocked) and e2e tests (real Fastify inject).