### PR TITLE
feat(webhooks): add merchant endpoint registration and hmac delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,10 @@ CREDIT_LINE_CONTRACT_ID=your_credit_line_contract_id
 
 # Redis URL for BullMQ background job queues
 REDIS_URL=redis://localhost:6379
+
+# ===========================================
+# ADMIN
+# ===========================================
+
+# Shared secret for /admin/* webhook inspection endpoints (x-admin-key header)
+ADMIN_API_KEY=change_me_admin_api_key

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,8 @@ import { TransactionsModule } from './modules/transactions/transactions.module';
 import { BlockchainIndexerModule } from './jobs/blockchain-indexer/blockchain-indexer.module';
 import { LoanPaymentReminderModule } from './jobs/loan-payment-reminder/loan-payment-reminder.module';
 import { TransactionStatusCheckerModule } from './jobs/transaction-status-checker/transaction-status-checker.module';
+import { WebhookDeliveryModule } from './jobs/webhook-delivery/webhook-delivery.module';
+import { WebhooksModule } from './modules/webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -49,6 +51,8 @@ import { TransactionStatusCheckerModule } from './jobs/transaction-status-checke
     BlockchainIndexerModule,
     LoanPaymentReminderModule,
     TransactionStatusCheckerModule,
+    WebhookDeliveryModule,
+    WebhooksModule,
   ],
   controllers: [],
   providers: [

--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -1,0 +1,32 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AdminApiKeyGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const expected = this.config.get<string>('ADMIN_API_KEY');
+    if (!expected) {
+      throw new UnauthorizedException({
+        code: 'ADMIN_NOT_CONFIGURED',
+        message: 'ADMIN_API_KEY is not configured.',
+      });
+    }
+    const request = context.switchToHttp().getRequest();
+    const provided = request.headers['x-admin-key'];
+    if (provided !== expected) {
+      throw new ForbiddenException({
+        code: 'ADMIN_FORBIDDEN',
+        message: 'Invalid admin API key.',
+      });
+    }
+    return true;
+  }
+}

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -17,6 +17,15 @@ export function setupSwagger(app: INestApplication): void {
       },
       'JWT-auth',
     )
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'x-admin-key',
+        in: 'header',
+        description: 'Admin API key for webhook inspection endpoints',
+      },
+      'admin-key',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/database/repositories/loans.repository.ts
+++ b/src/database/repositories/loans.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, InternalServerErrorException } from "@nestjs/common";
+import { Injectable, InternalServerErrorException, Optional } from "@nestjs/common";
+import { WebhookDispatchService } from "../../jobs/webhook-delivery/webhook-dispatch.service";
 import { SupabaseService } from "../supabase.client";
 
 export interface LoanRecord {
@@ -50,7 +51,10 @@ export interface LoanBalanceRecord {
 
 @Injectable()
 export class LoansRepository {
-  constructor(private readonly supabaseService: SupabaseService) {}
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    @Optional() private readonly webhookDispatch?: WebhookDispatchService,
+  ) {}
 
   async findById(
     id: string,
@@ -183,6 +187,7 @@ export class LoansRepository {
     status: string,
     onlyFromStatus?: string,
   ): Promise<void> {
+    const before = await this.findWebhookContext(loanId, userWallet);
     let query = this.supabaseService
       .getServiceRoleClient()
       .from("loans")
@@ -196,6 +201,7 @@ export class LoansRepository {
 
     const { error } = await query;
     this.throwOnError(error);
+    await this.dispatchStatusChange(before, status, userWallet);
   }
 
   async updateByLoanIdAndWallet(
@@ -203,6 +209,8 @@ export class LoansRepository {
     userWallet: string,
     values: Record<string, unknown>,
   ): Promise<void> {
+    const nextStatus = typeof values.status === "string" ? values.status : undefined;
+    const before = nextStatus ? await this.findWebhookContext(loanId, userWallet) : null;
     const { error } = await this.supabaseService
       .getServiceRoleClient()
       .from("loans")
@@ -211,6 +219,41 @@ export class LoansRepository {
       .eq("user_wallet", userWallet);
 
     this.throwOnError(error);
+    if (nextStatus) {
+      await this.dispatchStatusChange(before, nextStatus, userWallet);
+    }
+  }
+
+  private async findWebhookContext(
+    loanId: string,
+    userWallet: string,
+  ): Promise<{ loan_id: string; merchant_id: string | null; status: string } | null> {
+    const { data, error } = await this.supabaseService
+      .getServiceRoleClient()
+      .from("loans")
+      .select("loan_id, merchant_id, status")
+      .eq("loan_id", loanId)
+      .eq("user_wallet", userWallet)
+      .maybeSingle();
+    this.throwOnError(error);
+    return data as { loan_id: string; merchant_id: string | null; status: string } | null;
+  }
+
+  private async dispatchStatusChange(
+    before: { loan_id: string; merchant_id: string | null; status: string } | null,
+    nextStatus: string,
+    userWallet: string,
+  ): Promise<void> {
+    if (!this.webhookDispatch || !before || before.status === nextStatus) {
+      return;
+    }
+    await this.webhookDispatch.enqueueLoanStatusChange({
+      loanId: before.loan_id,
+      merchantId: before.merchant_id,
+      userWallet,
+      previousStatus: before.status,
+      status: nextStatus,
+    });
   }
 
   async recordPayment(payment: Record<string, unknown>): Promise<void> {

--- a/src/jobs/webhook-delivery/webhook-delivery.module.ts
+++ b/src/jobs/webhook-delivery/webhook-delivery.module.ts
@@ -1,0 +1,19 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SupabaseService } from '../../database/supabase.client';
+import { WebhookDeliveryProcessor } from './webhook-delivery.processor';
+import { WebhookDispatchService, WEBHOOK_QUEUE } from './webhook-dispatch.service';
+import { FetchWebhookHttpClient, WebhookHttpClient } from './webhook-http.client';
+
+@Module({
+  imports: [ConfigModule, BullModule.registerQueue({ name: WEBHOOK_QUEUE })],
+  providers: [
+    WebhookDispatchService,
+    WebhookDeliveryProcessor,
+    SupabaseService,
+    { provide: WebhookHttpClient, useClass: FetchWebhookHttpClient },
+  ],
+  exports: [WebhookDispatchService, BullModule],
+})
+export class WebhookDeliveryModule {}

--- a/src/jobs/webhook-delivery/webhook-delivery.processor.ts
+++ b/src/jobs/webhook-delivery/webhook-delivery.processor.ts
@@ -1,0 +1,108 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { SupabaseService } from '../../database/supabase.client';
+import {
+  signPayload,
+  WEBHOOK_DELIVERY_HEADER,
+  WEBHOOK_EVENT_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+} from '../../modules/webhooks/hmac.util';
+import { WEBHOOK_QUEUE, type WebhookJobData } from './webhook-dispatch.service';
+import { WebhookHttpClient } from './webhook-http.client';
+
+@Processor(WEBHOOK_QUEUE)
+export class WebhookDeliveryProcessor extends WorkerHost {
+  private readonly logger = new Logger(WebhookDeliveryProcessor.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly http: WebhookHttpClient,
+  ) {
+    super();
+  }
+
+  async process(job: Job<WebhookJobData>): Promise<void> {
+    const { deliveryId, endpointId } = job.data;
+    const db = this.supabase.getServiceRoleClient();
+
+    const { data: delivery, error: deliveryError } = await db
+      .from('webhook_deliveries')
+      .select('*')
+      .eq('id', deliveryId)
+      .maybeSingle();
+
+    if (deliveryError || !delivery) {
+      throw new Error(`Delivery ${deliveryId} not found`);
+    }
+    if (delivery.status === 'success') {
+      this.logger.log(
+        { context: 'WebhookDeliveryProcessor', action: 'skipDelivered', deliveryId },
+        'Skipping already successful delivery',
+      );
+      return;
+    }
+
+    const { data: endpoint, error: endpointError } = await db
+      .from('webhook_endpoints')
+      .select('id, url, secret, is_active')
+      .eq('id', endpointId)
+      .maybeSingle();
+
+    if (endpointError || !endpoint || !endpoint.is_active) {
+      await this.mark(deliveryId, job.attemptsMade + 1, 'failed', null, 'endpoint inactive or missing');
+      return;
+    }
+
+    const rawBody = JSON.stringify(delivery.payload);
+    const timestamp = new Date().toISOString();
+    const headers = {
+      [WEBHOOK_SIGNATURE_HEADER]: signPayload(endpoint.secret, rawBody),
+      [WEBHOOK_EVENT_HEADER]: delivery.event,
+      [WEBHOOK_DELIVERY_HEADER]: deliveryId,
+      [WEBHOOK_TIMESTAMP_HEADER]: timestamp,
+    };
+
+    try {
+      const response = await this.http.post(endpoint.url, rawBody, headers);
+      const ok = response.status >= 200 && response.status < 300;
+      await this.mark(
+        deliveryId,
+        job.attemptsMade + 1,
+        ok ? 'success' : 'failed',
+        response.status,
+        ok ? null : `HTTP ${response.status}`,
+      );
+      if (!ok) {
+        throw new Error(`Webhook endpoint returned HTTP ${response.status}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('Webhook endpoint returned HTTP')) {
+        await this.mark(deliveryId, job.attemptsMade + 1, 'failed', null, message);
+      }
+      throw error;
+    }
+  }
+
+  private async mark(
+    deliveryId: string,
+    attempts: number,
+    status: 'success' | 'failed',
+    responseCode: number | null,
+    lastError: string | null,
+  ): Promise<void> {
+    const db = this.supabase.getServiceRoleClient();
+    await db
+      .from('webhook_deliveries')
+      .update({
+        attempts,
+        status,
+        response_code: responseCode,
+        last_error: lastError,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', deliveryId);
+  }
+}

--- a/src/jobs/webhook-delivery/webhook-dispatch.service.ts
+++ b/src/jobs/webhook-delivery/webhook-dispatch.service.ts
@@ -1,0 +1,150 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { Queue } from 'bullmq';
+import { SupabaseService } from '../../database/supabase.client';
+
+export const WEBHOOK_QUEUE = 'webhook-delivery';
+export const LOAN_STATUS_CHANGED = 'loan.status_changed';
+
+export interface LoanStatusChangeEvent {
+  loanId: string;
+  merchantId: string | null;
+  userWallet: string;
+  previousStatus: string;
+  status: string;
+}
+
+export interface WebhookJobData {
+  deliveryId: string;
+  endpointId: string;
+  eventId: string;
+}
+
+@Injectable()
+export class WebhookDispatchService {
+  private readonly logger = new Logger(WebhookDispatchService.name);
+
+  constructor(
+    @InjectQueue(WEBHOOK_QUEUE) private readonly queue: Queue,
+    private readonly supabase: SupabaseService,
+  ) {}
+
+  async enqueueLoanStatusChange(event: LoanStatusChangeEvent): Promise<void> {
+    if (!event.merchantId || event.previousStatus === event.status) {
+      return;
+    }
+
+    const db = this.supabase.getServiceRoleClient();
+    const { data: endpoints, error } = await db
+      .from('webhook_endpoints')
+      .select('id, events, is_active')
+      .eq('merchant_id', event.merchantId)
+      .eq('is_active', true);
+
+    if (error) {
+      this.logger.error(
+        {
+          context: 'WebhookDispatchService',
+          action: 'listEndpoints',
+          error: error.message,
+        },
+        'Failed to load webhook endpoints',
+      );
+      return;
+    }
+
+    const targets = (endpoints ?? []).filter(
+      (row: { events?: string[] }) =>
+        Array.isArray(row.events) && row.events.includes(LOAN_STATUS_CHANGED),
+    );
+
+    const occurredAt = new Date().toISOString();
+    const eventId = `${event.loanId}:${event.previousStatus}:${event.status}`;
+    const payload = {
+      event: LOAN_STATUS_CHANGED,
+      event_id: eventId,
+      occurred_at: occurredAt,
+      data: {
+        loan_id: event.loanId,
+        merchant_id: event.merchantId,
+        user_wallet: event.userWallet,
+        previous_status: event.previousStatus,
+        status: event.status,
+      },
+    };
+
+    for (const endpoint of targets as { id: string }[]) {
+      const deliveryId = await this.ensureDelivery(endpoint.id, eventId, payload, occurredAt);
+      if (!deliveryId) {
+        continue;
+      }
+
+      await this.queue.add(
+        'deliver',
+        {
+          deliveryId,
+          endpointId: endpoint.id,
+          eventId,
+        } satisfies WebhookJobData,
+        {
+          attempts: 5,
+          backoff: { type: 'exponential', delay: 2000 },
+          removeOnComplete: { count: 100 },
+          removeOnFail: { count: 200 },
+          jobId: `${endpoint.id}:${eventId}`,
+        },
+      );
+    }
+  }
+
+  private async ensureDelivery(
+    endpointId: string,
+    eventId: string,
+    payload: Record<string, unknown>,
+    occurredAt: string,
+  ): Promise<string | null> {
+    const db = this.supabase.getServiceRoleClient();
+    const { data, error } = await db
+      .from('webhook_deliveries')
+      .insert({
+        endpoint_id: endpointId,
+        event_id: eventId,
+        event: LOAN_STATUS_CHANGED,
+        payload,
+        status: 'pending',
+        attempts: 0,
+        updated_at: occurredAt,
+      })
+      .select('id, status')
+      .maybeSingle();
+
+    if (!error && data?.id) {
+      return data.id as string;
+    }
+
+    if (error && error.code !== '23505') {
+      this.logger.error(
+        {
+          context: 'WebhookDispatchService',
+          action: 'insertDelivery',
+          endpointId,
+          error: error.message,
+        },
+        'Failed to persist webhook delivery',
+      );
+      return null;
+    }
+
+    const existing = await db
+      .from('webhook_deliveries')
+      .select('id, status')
+      .eq('endpoint_id', endpointId)
+      .eq('event_id', eventId)
+      .maybeSingle();
+
+    if (!existing.data || existing.data.status === 'success') {
+      return null;
+    }
+    return existing.data.id as string;
+  }
+}

--- a/src/jobs/webhook-delivery/webhook-http.client.ts
+++ b/src/jobs/webhook-delivery/webhook-http.client.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+export interface WebhookHttpResponse {
+  status: number;
+  body: string;
+}
+
+export abstract class WebhookHttpClient {
+  abstract post(
+    url: string,
+    rawBody: string,
+    headers: Record<string, string>,
+  ): Promise<WebhookHttpResponse>;
+}
+
+@Injectable()
+export class FetchWebhookHttpClient extends WebhookHttpClient {
+  async post(
+    url: string,
+    rawBody: string,
+    headers: Record<string, string>,
+  ): Promise<WebhookHttpResponse> {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...headers,
+      },
+      body: rawBody,
+    });
+    const body = await response.text();
+    return { status: response.status, body };
+  }
+}

--- a/src/modules/loans/loans.module.ts
+++ b/src/modules/loans/loans.module.ts
@@ -13,12 +13,14 @@ import { CreditLineContractClient } from '../../blockchain/contracts/credit-line
 import { ReputationContractClient } from '../../blockchain/contracts/reputation-contract.client';
 import { IdempotencyInterceptor } from '../../common/interceptors/idempotency.interceptor';
 import { getRedisConfig } from '../../config/redis.config';
+import { WebhookDeliveryModule } from '../../jobs/webhook-delivery/webhook-delivery.module';
 
 @Module({
   imports: [
     ConfigModule,
     AuthModule,
     ReputationModule,
+    WebhookDeliveryModule,
     CacheModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/modules/webhooks/admin-webhooks.controller.ts
+++ b/src/modules/webhooks/admin-webhooks.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminApiKeyGuard } from '../../common/guards/admin-api-key.guard';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { WebhooksService } from './webhooks.service';
+
+@ApiTags('Admin Webhooks')
+@ApiHeader({ name: 'x-admin-key', required: true })
+@Controller('admin/webhooks')
+@UseGuards(AdminApiKeyGuard)
+export class AdminWebhooksController {
+  constructor(private readonly webhooks: WebhooksService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all webhook subscriptions' })
+  list() {
+    return this.webhooks.adminList();
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'Inspect delivery logs for a webhook subscription' })
+  deliveries(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.webhooks.adminDeliveries(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update or deactivate a webhook subscription' })
+  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: UpdateWebhookDto) {
+    return this.webhooks.adminUpdate(id, dto);
+  }
+}

--- a/src/modules/webhooks/dto/create-webhook.dto.ts
+++ b/src/modules/webhooks/dto/create-webhook.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateWebhookDto {
+  @ApiProperty({ example: 'https://merchant.example/webhooks/trustup' })
+  @IsUrl({ require_tld: false })
+  url: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    example: ['loan.status_changed'],
+    default: ['loan.status_changed'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  events?: string[];
+}

--- a/src/modules/webhooks/dto/update-webhook.dto.ts
+++ b/src/modules/webhooks/dto/update-webhook.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsBoolean, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class UpdateWebhookDto {
+  @ApiPropertyOptional({ example: 'https://merchant.example/webhooks/trustup' })
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  url?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  events?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  is_active?: boolean;
+}

--- a/src/modules/webhooks/hmac.util.ts
+++ b/src/modules/webhooks/hmac.util.ts
@@ -1,0 +1,28 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+export const WEBHOOK_SIGNATURE_HEADER = 'x-trustup-signature';
+export const WEBHOOK_EVENT_HEADER = 'x-trustup-event';
+export const WEBHOOK_DELIVERY_HEADER = 'x-trustup-delivery';
+export const WEBHOOK_TIMESTAMP_HEADER = 'x-trustup-timestamp';
+
+export function generateWebhookSecret(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function signPayload(secret: string, rawBody: string): string {
+  const digest = createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+  return `sha256=${digest}`;
+}
+
+export function verifySignature(secret: string, rawBody: string, header: string): boolean {
+  if (!header || !secret) {
+    return false;
+  }
+  const expected = signPayload(secret, rawBody);
+  const a = Buffer.from(header);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}

--- a/src/modules/webhooks/webhooks.controller.ts
+++ b/src/modules/webhooks/webhooks.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { WebhooksService } from './webhooks.service';
+
+@ApiTags('Webhooks')
+@ApiBearerAuth('JWT-auth')
+@Controller('webhooks')
+@UseGuards(JwtAuthGuard)
+export class WebhooksController {
+  constructor(private readonly webhooks: WebhooksService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Register an outbound webhook endpoint for the authenticated merchant' })
+  @ApiResponse({ status: 201, description: 'Endpoint created. Secret is returned once.' })
+  create(@CurrentUser() user: { wallet: string }, @Body() dto: CreateWebhookDto) {
+    return this.webhooks.create(user.wallet, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List webhook endpoints for the authenticated merchant' })
+  list(@CurrentUser() user: { wallet: string }) {
+    return this.webhooks.listMine(user.wallet);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a webhook endpoint owned by the authenticated merchant' })
+  getOne(@CurrentUser() user: { wallet: string }, @Param('id', new ParseUUIDPipe()) id: string) {
+    return this.webhooks.getMine(user.wallet, id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a webhook endpoint owned by the authenticated merchant' })
+  update(
+    @CurrentUser() user: { wallet: string },
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateWebhookDto,
+  ) {
+    return this.webhooks.updateMine(user.wallet, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a webhook endpoint owned by the authenticated merchant' })
+  remove(@CurrentUser() user: { wallet: string }, @Param('id', new ParseUUIDPipe()) id: string) {
+    return this.webhooks.deleteMine(user.wallet, id);
+  }
+}

--- a/src/modules/webhooks/webhooks.module.ts
+++ b/src/modules/webhooks/webhooks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MerchantsRepository } from '../../database/repositories/merchants.repository';
+import { SupabaseService } from '../../database/supabase.client';
+import { AdminWebhooksController } from './admin-webhooks.controller';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+
+@Module({
+  controllers: [WebhooksController, AdminWebhooksController],
+  providers: [WebhooksService, MerchantsRepository, SupabaseService],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -1,0 +1,183 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { MerchantsRepository } from '../../database/repositories/merchants.repository';
+import { SupabaseService } from '../../database/supabase.client';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { generateWebhookSecret } from './hmac.util';
+
+const DEFAULT_EVENTS = ['loan.status_changed'];
+
+@Injectable()
+export class WebhooksService {
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly merchants: MerchantsRepository,
+  ) {}
+
+  async create(wallet: string, dto: CreateWebhookDto) {
+    const merchant = await this.requireMerchant(wallet);
+    const secret = generateWebhookSecret();
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .insert({
+        merchant_id: merchant.id,
+        url: dto.url,
+        secret,
+        events: dto.events?.length ? dto.events : DEFAULT_EVENTS,
+        is_active: true,
+      })
+      .select('id, merchant_id, url, events, is_active, created_at, updated_at, secret')
+      .single();
+
+    if (error?.code === '23505') {
+      throw new ConflictException({
+        code: 'WEBHOOK_URL_EXISTS',
+        message: 'A webhook for this URL is already registered.',
+      });
+    }
+    this.throwOnError(error);
+    return data;
+  }
+
+  async listMine(wallet: string) {
+    const merchant = await this.requireMerchant(wallet);
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .select('id, merchant_id, url, events, is_active, created_at, updated_at')
+      .eq('merchant_id', merchant.id)
+      .order('created_at', { ascending: false });
+    this.throwOnError(error);
+    return { endpoints: data ?? [] };
+  }
+
+  async getMine(wallet: string, id: string) {
+    const merchant = await this.requireMerchant(wallet);
+    const endpoint = await this.getEndpoint(id);
+    this.assertOwner(endpoint.merchant_id, merchant.id);
+    return this.publicEndpoint(endpoint);
+  }
+
+  async updateMine(wallet: string, id: string, dto: UpdateWebhookDto) {
+    const merchant = await this.requireMerchant(wallet);
+    const endpoint = await this.getEndpoint(id);
+    this.assertOwner(endpoint.merchant_id, merchant.id);
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .update({
+        ...(dto.url !== undefined ? { url: dto.url } : {}),
+        ...(dto.events !== undefined ? { events: dto.events } : {}),
+        ...(dto.is_active !== undefined ? { is_active: dto.is_active } : {}),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select('id, merchant_id, url, events, is_active, created_at, updated_at')
+      .single();
+    this.throwOnError(error);
+    return data;
+  }
+
+  async deleteMine(wallet: string, id: string) {
+    const merchant = await this.requireMerchant(wallet);
+    const endpoint = await this.getEndpoint(id);
+    this.assertOwner(endpoint.merchant_id, merchant.id);
+    const { error } = await this.db().from('webhook_endpoints').delete().eq('id', id);
+    this.throwOnError(error);
+    return { success: true };
+  }
+
+  async adminList() {
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .select('id, merchant_id, url, events, is_active, created_at, updated_at')
+      .order('created_at', { ascending: false });
+    this.throwOnError(error);
+    return { endpoints: data ?? [] };
+  }
+
+  async adminDeliveries(endpointId: string) {
+    await this.getEndpoint(endpointId);
+    const { data, error } = await this.db()
+      .from('webhook_deliveries')
+      .select(
+        'id, endpoint_id, event_id, event, status, attempts, response_code, last_error, created_at, updated_at',
+      )
+      .eq('endpoint_id', endpointId)
+      .order('created_at', { ascending: false })
+      .limit(100);
+    this.throwOnError(error);
+    return { deliveries: data ?? [] };
+  }
+
+  async adminUpdate(id: string, dto: UpdateWebhookDto) {
+    await this.getEndpoint(id);
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .update({
+        ...(dto.url !== undefined ? { url: dto.url } : {}),
+        ...(dto.events !== undefined ? { events: dto.events } : {}),
+        ...(dto.is_active !== undefined ? { is_active: dto.is_active } : {}),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select('id, merchant_id, url, events, is_active, created_at, updated_at')
+      .single();
+    this.throwOnError(error);
+    return data;
+  }
+
+  private async requireMerchant(wallet: string) {
+    const merchant = await this.merchants.findByWallet(wallet);
+    if (!merchant) {
+      throw new ForbiddenException({
+        code: 'MERCHANT_REQUIRED',
+        message: 'Webhook registration is limited to merchant wallets.',
+      });
+    }
+    return merchant;
+  }
+
+  private async getEndpoint(id: string) {
+    const { data, error } = await this.db()
+      .from('webhook_endpoints')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    this.throwOnError(error);
+    if (!data) {
+      throw new NotFoundException({
+        code: 'WEBHOOK_NOT_FOUND',
+        message: 'Webhook endpoint not found.',
+      });
+    }
+    return data;
+  }
+
+  private assertOwner(ownerId: string, merchantId: string) {
+    if (ownerId !== merchantId) {
+      throw new NotFoundException({
+        code: 'WEBHOOK_NOT_FOUND',
+        message: 'Webhook endpoint not found.',
+      });
+    }
+  }
+
+  private publicEndpoint(row: Record<string, unknown>) {
+    const { secret: _secret, ...rest } = row;
+    return rest;
+  }
+
+  private db() {
+    return this.supabase.getServiceRoleClient();
+  }
+
+  private throwOnError(error: { message?: string } | null): void {
+    if (error) {
+      throw error;
+    }
+  }
+}

--- a/supabase/migrations/20260820120000_create_webhook_tables.sql
+++ b/supabase/migrations/20260820120000_create_webhook_tables.sql
@@ -1,0 +1,43 @@
+-- Outbound merchant webhook subscriptions and delivery logs (issue #133)
+
+CREATE TABLE IF NOT EXISTS public.webhook_endpoints (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  merchant_id UUID NOT NULL REFERENCES public.merchants(id) ON DELETE CASCADE,
+  url         TEXT NOT NULL,
+  secret      TEXT NOT NULL,
+  events      TEXT[] NOT NULL DEFAULT ARRAY['loan.status_changed']::TEXT[],
+  is_active   BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (merchant_id, url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_merchant ON public.webhook_endpoints(merchant_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_active ON public.webhook_endpoints(is_active);
+
+CREATE TABLE IF NOT EXISTS public.webhook_deliveries (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  endpoint_id   UUID NOT NULL REFERENCES public.webhook_endpoints(id) ON DELETE CASCADE,
+  event_id      TEXT NOT NULL,
+  event         TEXT NOT NULL,
+  payload       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status        TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'success', 'failed')),
+  attempts      INTEGER NOT NULL DEFAULT 0,
+  response_code INTEGER,
+  last_error    TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (endpoint_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_endpoint ON public.webhook_deliveries(endpoint_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON public.webhook_deliveries(status);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created ON public.webhook_deliveries(created_at DESC);
+
+ALTER TABLE public.webhook_endpoints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.webhook_endpoints IS 'Merchant-registered outbound webhook URLs. Nest uses the service role key.';
+COMMENT ON TABLE public.webhook_deliveries IS 'Per-attempt log for outbound webhook deliveries.';
+COMMENT ON COLUMN public.webhook_deliveries.event_id IS 'Idempotency key for a single logical event (endpoint + event_id unique).';

--- a/test/e2e/modules/webhooks/webhook-delivery.e2e-spec.ts
+++ b/test/e2e/modules/webhooks/webhook-delivery.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { WebhookDeliveryProcessor } from '../../../../src/jobs/webhook-delivery/webhook-delivery.processor';
+import { WebhookHttpClient } from '../../../../src/jobs/webhook-delivery/webhook-http.client';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { createMockJob } from '../../../helpers/job.helpers';
+import type { WebhookJobData } from '../../../../src/jobs/webhook-delivery/webhook-dispatch.service';
+
+/**
+ * Integration-style processor flow: first HTTP attempt fails, retry succeeds.
+ * Uses an in-memory fake of Supabase + HTTP so CI does not need Redis.
+ */
+describe('webhook delivery retry flow', () => {
+  it('marks failed then success across two process() calls', async () => {
+    const delivery = {
+      id: 'd1',
+      status: 'pending',
+      event: 'loan.status_changed',
+      payload: { event: 'loan.status_changed', event_id: 'loan-1:pending:active' },
+    };
+    const updates: Record<string, unknown>[] = [];
+    const db = {
+      from: (table: string) => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => {
+              if (table === 'webhook_deliveries') {
+                return { data: delivery, error: null };
+              }
+              return {
+                data: {
+                  id: 'e1',
+                  url: 'https://merchant.test/hooks',
+                  secret: 'secret',
+                  is_active: true,
+                },
+                error: null,
+              };
+            },
+          }),
+        }),
+        update: (row: Record<string, unknown>) => {
+          updates.push(row);
+          if (typeof row.status === 'string') {
+            delivery.status = row.status;
+          }
+          return { eq: async () => ({ error: null }) };
+        },
+      }),
+    };
+
+    let calls = 0;
+    const http: WebhookHttpClient = {
+      post: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return { status: 503, body: 'busy' };
+        }
+        return { status: 204, body: '' };
+      },
+    };
+
+    const processor = new WebhookDeliveryProcessor(
+      { getServiceRoleClient: () => db } as unknown as SupabaseService,
+      http,
+    );
+
+    const job = createMockJob<WebhookJobData>({
+      data: { deliveryId: 'd1', endpointId: 'e1', eventId: 'loan-1:pending:active' },
+      attemptsMade: 0,
+    });
+
+    await expect(processor.process(job)).rejects.toThrow('HTTP 503');
+    expect(delivery.status).toBe('failed');
+
+    job.attemptsMade = 1;
+    await processor.process(job);
+    expect(delivery.status).toBe('success');
+    expect(calls).toBe(2);
+    expect(updates.map((u) => u.status)).toEqual(['failed', 'success']);
+  });
+});

--- a/test/unit/jobs/webhook-delivery/webhook-delivery.processor.spec.ts
+++ b/test/unit/jobs/webhook-delivery/webhook-delivery.processor.spec.ts
@@ -1,0 +1,98 @@
+import { Test } from '@nestjs/testing';
+import { WebhookDeliveryProcessor } from '../../../../src/jobs/webhook-delivery/webhook-delivery.processor';
+import { WebhookHttpClient } from '../../../../src/jobs/webhook-delivery/webhook-http.client';
+import { SupabaseService } from '../../../../src/database/supabase.client';
+import { createMockJob, createSupabaseChainMock } from '../../../helpers/job.helpers';
+import { signPayload, verifySignature } from '../../../../src/modules/webhooks/hmac.util';
+import type { WebhookJobData } from '../../../../src/jobs/webhook-delivery/webhook-dispatch.service';
+
+describe('WebhookDeliveryProcessor', () => {
+  let processor: WebhookDeliveryProcessor;
+  let http: { post: jest.Mock };
+  let deliveriesChain: ReturnType<typeof createSupabaseChainMock>;
+  let endpointsChain: ReturnType<typeof createSupabaseChainMock>;
+  const client = { from: jest.fn() };
+
+  beforeEach(async () => {
+    deliveriesChain = createSupabaseChainMock();
+    endpointsChain = createSupabaseChainMock();
+    client.from.mockImplementation((table: string) =>
+      table === 'webhook_deliveries' ? deliveriesChain : endpointsChain,
+    );
+    http = { post: jest.fn() };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryProcessor,
+        { provide: SupabaseService, useValue: { getServiceRoleClient: () => client } },
+        { provide: WebhookHttpClient, useValue: http },
+      ],
+    }).compile();
+
+    processor = module.get(WebhookDeliveryProcessor);
+  });
+
+  const job = createMockJob<WebhookJobData>({
+    data: { deliveryId: 'd1', endpointId: 'e1', eventId: 'loan:pending:active' },
+    attemptsMade: 0,
+  });
+
+  it('POSTs a signed payload and marks success on 2xx', async () => {
+    const payload = { event: 'loan.status_changed', event_id: 'loan:pending:active' };
+    deliveriesChain.maybeSingle
+      .mockResolvedValueOnce({
+        data: { id: 'd1', status: 'pending', event: 'loan.status_changed', payload },
+        error: null,
+      });
+    endpointsChain.maybeSingle.mockResolvedValue({
+      data: { id: 'e1', url: 'https://example.test/hook', secret: 's3cret', is_active: true },
+      error: null,
+    });
+    http.post.mockResolvedValue({ status: 200, body: 'ok' });
+
+    await processor.process(job);
+
+    expect(http.post).toHaveBeenCalled();
+    const [url, rawBody, headers] = http.post.mock.calls[0];
+    expect(url).toBe('https://example.test/hook');
+    expect(verifySignature('s3cret', rawBody, headers['x-trustup-signature'])).toBe(true);
+    expect(headers['x-trustup-event']).toBe('loan.status_changed');
+    expect(deliveriesChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', response_code: 200 }),
+    );
+  });
+
+  it('retries by throwing when the endpoint returns a non-2xx status', async () => {
+    deliveriesChain.maybeSingle.mockResolvedValue({
+      data: { id: 'd1', status: 'pending', event: 'loan.status_changed', payload: {} },
+      error: null,
+    });
+    endpointsChain.maybeSingle.mockResolvedValue({
+      data: { id: 'e1', url: 'https://example.test/hook', secret: 's3cret', is_active: true },
+      error: null,
+    });
+    http.post.mockResolvedValue({ status: 500, body: 'nope' });
+
+    await expect(processor.process(job)).rejects.toThrow('HTTP 500');
+    expect(deliveriesChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', response_code: 500 }),
+    );
+  });
+
+  it('is idempotent for an already successful delivery', async () => {
+    deliveriesChain.maybeSingle.mockResolvedValue({
+      data: { id: 'd1', status: 'success', event: 'loan.status_changed', payload: {} },
+      error: null,
+    });
+
+    await processor.process(job);
+    expect(http.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('HMAC retry payload stability', () => {
+  it('produces the same signature for the same raw body', () => {
+    const body = '{"event":"loan.status_changed"}';
+    expect(signPayload('abc', body)).toBe(signPayload('abc', body));
+  });
+});

--- a/test/unit/modules/webhooks/hmac.util.spec.ts
+++ b/test/unit/modules/webhooks/hmac.util.spec.ts
@@ -1,0 +1,31 @@
+import { signPayload, verifySignature } from '../../../../src/modules/webhooks/hmac.util';
+
+describe('webhook HMAC', () => {
+  const secret = 'test-secret';
+  const body = JSON.stringify({ event: 'loan.status_changed', event_id: 'abc' });
+
+  it('signs with sha256 hex prefix', () => {
+    const header = signPayload(secret, body);
+    expect(header.startsWith('sha256=')).toBe(true);
+    expect(header.length).toBe('sha256='.length + 64);
+  });
+
+  it('verifies a matching signature', () => {
+    const header = signPayload(secret, body);
+    expect(verifySignature(secret, body, header)).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    const header = signPayload(secret, body);
+    expect(verifySignature(secret, body + ' ', header)).toBe(false);
+  });
+
+  it('rejects a wrong secret', () => {
+    const header = signPayload(secret, body);
+    expect(verifySignature('other', body, header)).toBe(false);
+  });
+
+  it('rejects empty header', () => {
+    expect(verifySignature(secret, body, '')).toBe(false);
+  });
+});

--- a/test/unit/modules/webhooks/webhooks.service.spec.ts
+++ b/test/unit/modules/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,13 @@
+import { ForbiddenException } from '@nestjs/common';
+import { WebhooksService } from '../../../../src/modules/webhooks/webhooks.service';
+
+describe('WebhooksService.create', () => {
+  it('rejects non-merchant wallets', async () => {
+    const merchants = { findByWallet: jest.fn().mockResolvedValue(null) };
+    const supabase = { getServiceRoleClient: jest.fn() };
+    const svc = new WebhooksService(supabase as never, merchants as never);
+    await expect(
+      svc.create('GABC', { url: 'https://example.test/hook' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});


### PR DESCRIPTION
## Summary

Adds outbound webhook delivery so merchants are notified when a customer loan status changes. There was no outbound webhook infrastructure in the repo (the existing KYC webhook is inbound-only).

Closes #133

Context: https://github.com/TrustUp-app/TrustUp-API/tree/main/docs

## Changes

- Migration `webhook_endpoints` + `webhook_deliveries` (\`supabase/migrations/20260820120000_create_webhook_tables.sql\`)
- Merchant CRUD at \`/webhooks\` (JWT must match a merchant wallet). Secret is returned once on create.
- Admin inspect/update at \`/admin/webhooks\` via \`x-admin-key\` (\`ADMIN_API_KEY\`)
- BullMQ queue \`webhook-delivery\` with 5 attempts and exponential backoff (2s base). No \`@Cron\` / \`@nestjs/schedule\`.
- HMAC-SHA256 over the raw JSON body (\`X-TrustUp-Signature: sha256=...\`)
- Delivery log: status attempts response code last error
- Trigger: \`LoansRepository.updateStatus\` / \`updateByLoanIdAndWallet\` enqueue \`loan.status_changed\` when status actually changes
- Idempotency: unique \`(endpoint_id, event_id)\` plus BullMQ \`jobId\` so retries do not double-deliver
- Swagger tags Webhooks / Admin Webhooks

## Acceptance criteria

- [x] Migration: webhook endpoint registration table (merchant url secret active events)
- [x] Endpoint registration CRUD (merchant-facing)
- [x] BullMQ delivery queue with exponential backoff retry
- [x] HMAC signature generation/verification
- [x] Delivery log table (status attempts response code)
- [x] Admin endpoints to inspect/manage subscriptions and delivery logs
- [x] Trigger delivery on loan status change
- [x] Unit tests for signing retry logic and queue processor
- [x] Integration tests covering full delivery + retry flow
- [x] Swagger documentation

## Verification

```bash
npx jest --runInBand
npm run test:e2e -- --testPathPattern=webhook
```

- Unit: 27 suites / 280 tests passed
- Webhook e2e retry flow passed

This repository has no test GitHub Actions workflow (only \`leaderboard.yml\`). Local jest is the gate.

## Notes

- HTTP client is injectable (\`WebhookHttpClient\`) so tests never hit the network
- \`nest build\` currently fails on a pre-existing Fastify helmet type mismatch in \`src/main.ts\` (untouched)
- Event name: \`loan.status_changed\`. Payload includes previous and next status.